### PR TITLE
[refactor][fix] 타워 랜덤배치 미적용 버그, 유닛 이동을 위한 선택이 안되는 버그 픽스

### DIFF
--- a/Bismuth/Assets/Prefabs/박승훈/Manager/GameManager.prefab
+++ b/Bismuth/Assets/Prefabs/박승훈/Manager/GameManager.prefab
@@ -15,6 +15,7 @@ GameObject:
   - component: {fileID: 651773196946485032}
   - component: {fileID: 3586491415078184626}
   - component: {fileID: 8554172300313096461}
+  - component: {fileID: 7012402871630413712}
   m_Layer: 0
   m_Name: GameManager
   m_TagString: Untagged
@@ -155,6 +156,8 @@ MonoBehaviour:
   boardSystem: {fileID: 0}
   synergyManager: {fileID: 8140035803927745397}
   playerDataManager: {fileID: 8423151259897990698}
+  cellHighlight: {fileID: 0}
+  worldCamera: {fileID: 0}
   units:
   - {fileID: 11400000, guid: 42c65043e3ed84a4f9d15502cdb0fc1e, type: 2}
   - {fileID: 11400000, guid: 6f6a3629b26de474c9fbdf776215566f, type: 2}
@@ -162,35 +165,36 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 8085adba1f3e175448a3a2a771effdcf, type: 2}
   summonSO: {fileID: 11400000, guid: 78cd8cc80ec1d984e9375d6e88f08fce, type: 2}
   unitPrefabTable:
-  - unitName: 
-    prefab: {fileID: 9038129889285653994, guid: 0b7d32999e2bd4641922d5b2f88d43c3, type: 3}
-  - unitName: 
-    prefab: {fileID: 150900313772879146, guid: ef0724b3312dc1d4f83e68b8a551a4f6, type: 3}
-  - unitName: 
-    prefab: {fileID: 3136620670785567480, guid: 2cdc27fb3bc84864f8008f3d0538ace4, type: 3}
-  - unitName: 
-    prefab: {fileID: 7940931687654057403, guid: 8a7c90bac69bb8041a0bbded055218ab, type: 3}
-  - unitName: 
-    prefab: {fileID: 6128681124006778371, guid: 0f62a6315a2b8ce4cb3e834e60234f5c, type: 3}
-  - unitName: 
-    prefab: {fileID: 8345079437586767415, guid: 52613da427ddd044ab8f6ec88e96a1df, type: 3}
-  - unitName: 
-    prefab: {fileID: 3043985807303402754, guid: 4833cf68e50bc5640b8e02da1da97fe8, type: 3}
-  - unitName: 
-    prefab: {fileID: 3240650641100634780, guid: f0bf43be8864e2444938b79c22eff229, type: 3}
-  - unitName: 
-    prefab: {fileID: 9156677081990422679, guid: c7f96a1bde826614db158b91ec382a6e, type: 3}
-  - unitName: 
-    prefab: {fileID: 6249043912539506680, guid: 3d1899f2d18f4ff42848a6fad7dd5068, type: 3}
-  - unitName: 
-    prefab: {fileID: 4591626632479377843, guid: 5ec828ae2a1693a419c371910603a722, type: 3}
-  - unitName: 
-    prefab: {fileID: 1683557987897090177, guid: 02cc90d7202b07f448059f086a715689, type: 3}
-  - unitName: 
-    prefab: {fileID: 7800846937348706959, guid: ba7c9865b117a68408f85e5538bd1e34, type: 3}
-  - unitName: 
-    prefab: {fileID: 2360913672812016886, guid: 45a0916c09920024d9fddb9eb11a264e, type: 3}
-  - unitName: 
-    prefab: {fileID: 6038061598566665019, guid: 1f333798b78d6f14aa3c901b5698b599, type: 3}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
   ownedTowers: []
   summonLog: 1
+--- !u!114 &7012402871630413712
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4351018382781704222}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3ad1b08b79f9ca14382a331f416dfafa, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::UnitPointerInputRouter
+  worldCamera: {fileID: 0}
+  unitLayer:
+    serializedVersion: 2
+    m_Bits: 32

--- a/Bismuth/Assets/Resources/Units/10001.prefab.meta
+++ b/Bismuth/Assets/Resources/Units/10001.prefab.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: c1aad0cdb6b11744fbee5a319d3286ad
+guid: 96371c857349f624abf7a9dd8f96a53c
 PrefabImporter:
   externalObjects: {}
   userData: 

--- a/Bismuth/Assets/Resources/Units/10002.prefab.meta
+++ b/Bismuth/Assets/Resources/Units/10002.prefab.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 3ce48dc4e8190124796aa529457e8f59
+guid: b0f40238e0287204eaa36625f6d3e2ca
 PrefabImporter:
   externalObjects: {}
   userData: 

--- a/Bismuth/Assets/Resources/Units/10003.prefab.meta
+++ b/Bismuth/Assets/Resources/Units/10003.prefab.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 1d189ead7db93144d8294940b246c2f7
+guid: b682cdfef63573e4bb2d8af47b88a7d8
 PrefabImporter:
   externalObjects: {}
   userData: 

--- a/Bismuth/Assets/Resources/Units/10004.prefab.meta
+++ b/Bismuth/Assets/Resources/Units/10004.prefab.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: d78deba55693d0f46be5f4a3dfe1587e
+guid: 2394e5aee696f6948b0ed9f6eb7c259e
 PrefabImporter:
   externalObjects: {}
   userData: 

--- a/Bismuth/Assets/Resources/Units/10005.prefab.meta
+++ b/Bismuth/Assets/Resources/Units/10005.prefab.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 53c770a7910ee5b43b124010835a8ba9
+guid: 13ece18a7c4c8f94aadac6b4b0001f43
 PrefabImporter:
   externalObjects: {}
   userData: 

--- a/Bismuth/Assets/Resources/Units/10006.prefab.meta
+++ b/Bismuth/Assets/Resources/Units/10006.prefab.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: a39f68dbc83ea72428e8103b02a94649
+guid: 04d88f80732b62849b145b9cfee35522
 PrefabImporter:
   externalObjects: {}
   userData: 

--- a/Bismuth/Assets/Resources/Units/10007.prefab.meta
+++ b/Bismuth/Assets/Resources/Units/10007.prefab.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: eb8306bedff8d5d4eb667e33bc8b720c
+guid: e7b2de87612e12c44ae694b0bb92cd6e
 PrefabImporter:
   externalObjects: {}
   userData: 

--- a/Bismuth/Assets/Resources/Units/10008.prefab.meta
+++ b/Bismuth/Assets/Resources/Units/10008.prefab.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 98bd86ebde9d225418243c9108fcf033
+guid: dfd46fc002f6e564d85e36bbce6c42bc
 PrefabImporter:
   externalObjects: {}
   userData: 

--- a/Bismuth/Assets/Resources/Units/10009.prefab.meta
+++ b/Bismuth/Assets/Resources/Units/10009.prefab.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 20439fba87fc49f4284e8fa554c2e6ea
+guid: 735c51d165e012a448a8a4fd5ad097bc
 PrefabImporter:
   externalObjects: {}
   userData: 

--- a/Bismuth/Assets/Resources/Units/10010.prefab.meta
+++ b/Bismuth/Assets/Resources/Units/10010.prefab.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 89123e1b24d937449bc9c078a101d732
+guid: dec4cad6c8ff30a4ebf112d2b608f337
 PrefabImporter:
   externalObjects: {}
   userData: 

--- a/Bismuth/Assets/Resources/Units/10011.prefab.meta
+++ b/Bismuth/Assets/Resources/Units/10011.prefab.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 8226eb8ac9b7ed5428047f69529caa68
+guid: 5cbe80cab2ce43443a867249c8d3c6f6
 PrefabImporter:
   externalObjects: {}
   userData: 

--- a/Bismuth/Assets/Resources/Units/10012.prefab.meta
+++ b/Bismuth/Assets/Resources/Units/10012.prefab.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: ceb274333da33af42af63de7d0d4fc9d
+guid: 9844672b505a3a14fb7d1ebf7d383d26
 PrefabImporter:
   externalObjects: {}
   userData: 

--- a/Bismuth/Assets/Resources/Units/10013.prefab.meta
+++ b/Bismuth/Assets/Resources/Units/10013.prefab.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: bf33c3f00b0d5ad46b463024b3da7a69
+guid: 6cbce5190e6d3a848812cdb01ecd6641
 PrefabImporter:
   externalObjects: {}
   userData: 

--- a/Bismuth/Assets/Resources/Units/10014.prefab.meta
+++ b/Bismuth/Assets/Resources/Units/10014.prefab.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: abe93491d00c8054fa2a982cc29ca319
+guid: ff8db8bf0b8479c4c94006c3545c0c46
 PrefabImporter:
   externalObjects: {}
   userData: 

--- a/Bismuth/Assets/Resources/Units/10015.prefab.meta
+++ b/Bismuth/Assets/Resources/Units/10015.prefab.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: bc98b0a1a008fe24e80eaaa8a63b41d6
+guid: 11a3ebce82ab9e4408f6ea054cccd946
 PrefabImporter:
   externalObjects: {}
   userData: 

--- a/Bismuth/Assets/Scenes/Stage1.unity
+++ b/Bismuth/Assets/Scenes/Stage1.unity
@@ -176,82 +176,6 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 2b1144a24b50f0d4dbb27a4242da1a01, type: 3}
---- !u!1 &88782407
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 88782408}
-  - component: {fileID: 88782410}
-  - component: {fileID: 88782409}
-  m_Layer: 5
-  m_Name: TowerPalletePanel
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &88782408
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 88782407}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0.2, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 345466167}
-  m_Father: {fileID: 2004171405}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 333, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &88782409
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 88782407}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 0.392}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
-  m_Type: 1
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
---- !u!222 &88782410
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 88782407}
-  m_CullTransparentMesh: 1
 --- !u!114 &95619001 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 219398841401376091, guid: d18713278c47e5449b9da2b2d82e727c, type: 3}
@@ -263,138 +187,139 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fba9d52d4be6290489e9e3ae07baf96d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::BoardSystem
---- !u!1 &345466166
-GameObject:
+--- !u!1001 &496014318
+PrefabInstance:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 345466167}
-  - component: {fileID: 345466171}
-  - component: {fileID: 345466170}
-  - component: {fileID: 345466169}
-  m_Layer: 5
-  m_Name: TowerSummonButton
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &345466167
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 345466166}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 3, y: 3, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 88782408}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 17, y: -93}
-  m_SizeDelta: {x: -684, y: -470}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &345466169
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 345466166}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Button
-  m_Navigation:
-    m_Mode: 3
-    m_WrapAround: 0
-    m_SelectOnUp: {fileID: 0}
-    m_SelectOnDown: {fileID: 0}
-    m_SelectOnLeft: {fileID: 0}
-    m_SelectOnRight: {fileID: 0}
-  m_Transition: 1
-  m_Colors:
-    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
-    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
-    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
-    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
-    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
-    m_ColorMultiplier: 1
-    m_FadeDuration: 0.1
-  m_SpriteState:
-    m_HighlightedSprite: {fileID: 0}
-    m_PressedSprite: {fileID: 0}
-    m_SelectedSprite: {fileID: 0}
-    m_DisabledSprite: {fileID: 0}
-  m_AnimationTriggers:
-    m_NormalTrigger: Normal
-    m_HighlightedTrigger: Highlighted
-    m_PressedTrigger: Pressed
-    m_SelectedTrigger: Selected
-    m_DisabledTrigger: Disabled
-  m_Interactable: 1
-  m_TargetGraphic: {fileID: 345466170}
-  m_OnClick:
-    m_PersistentCalls:
-      m_Calls:
-      - m_Target: {fileID: 1394565034}
-        m_TargetAssemblyTypeName: SummonManager, Assembly-CSharp
-        m_MethodName: SummonUnit
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
---- !u!114 &345466170
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 345466166}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: -4005623112494741349, guid: 1d920b7f994ef0f458cc9d9b68c44e6c, type: 3}
-  m_Type: 0
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
---- !u!222 &345466171
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 345466166}
-  m_CullTransparentMesh: 1
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 496947781755680397, guid: 1c1f7e5898091004eb43ca5d5136aa0d, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 1394565034}
+    - target: {fileID: 496947781755680397, guid: 1c1f7e5898091004eb43ca5d5136aa0d, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: SummonUnit
+      objectReference: {fileID: 0}
+    - target: {fileID: 1148112932772845760, guid: 1c1f7e5898091004eb43ca5d5136aa0d, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1148112932772845760, guid: 1c1f7e5898091004eb43ca5d5136aa0d, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1148112932772845760, guid: 1c1f7e5898091004eb43ca5d5136aa0d, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3276245877223818212, guid: 1c1f7e5898091004eb43ca5d5136aa0d, type: 3}
+      propertyPath: m_Name
+      value: Canvas
+      objectReference: {fileID: 0}
+    - target: {fileID: 3419785265950174632, guid: 1c1f7e5898091004eb43ca5d5136aa0d, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3419785265950174632, guid: 1c1f7e5898091004eb43ca5d5136aa0d, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231677636261445379, guid: 1c1f7e5898091004eb43ca5d5136aa0d, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231677636261445379, guid: 1c1f7e5898091004eb43ca5d5136aa0d, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231677636261445379, guid: 1c1f7e5898091004eb43ca5d5136aa0d, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231677636261445379, guid: 1c1f7e5898091004eb43ca5d5136aa0d, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231677636261445379, guid: 1c1f7e5898091004eb43ca5d5136aa0d, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231677636261445379, guid: 1c1f7e5898091004eb43ca5d5136aa0d, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231677636261445379, guid: 1c1f7e5898091004eb43ca5d5136aa0d, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231677636261445379, guid: 1c1f7e5898091004eb43ca5d5136aa0d, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231677636261445379, guid: 1c1f7e5898091004eb43ca5d5136aa0d, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231677636261445379, guid: 1c1f7e5898091004eb43ca5d5136aa0d, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231677636261445379, guid: 1c1f7e5898091004eb43ca5d5136aa0d, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231677636261445379, guid: 1c1f7e5898091004eb43ca5d5136aa0d, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231677636261445379, guid: 1c1f7e5898091004eb43ca5d5136aa0d, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231677636261445379, guid: 1c1f7e5898091004eb43ca5d5136aa0d, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231677636261445379, guid: 1c1f7e5898091004eb43ca5d5136aa0d, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231677636261445379, guid: 1c1f7e5898091004eb43ca5d5136aa0d, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231677636261445379, guid: 1c1f7e5898091004eb43ca5d5136aa0d, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231677636261445379, guid: 1c1f7e5898091004eb43ca5d5136aa0d, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231677636261445379, guid: 1c1f7e5898091004eb43ca5d5136aa0d, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5231677636261445379, guid: 1c1f7e5898091004eb43ca5d5136aa0d, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5888027716500233357, guid: 1c1f7e5898091004eb43ca5d5136aa0d, type: 3}
+      propertyPath: _synergyManager
+      value: 
+      objectReference: {fileID: 2058181465}
+    - target: {fileID: 8297800164729030232, guid: 1c1f7e5898091004eb43ca5d5136aa0d, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 1c1f7e5898091004eb43ca5d5136aa0d, type: 3}
 --- !u!1001 &690380120
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -460,6 +385,11 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 407827aefabc9bb4aa8c747fcf7f977c, type: 3}
+--- !u!20 &950284288 stripped
+Camera:
+  m_CorrespondingSourceObject: {fileID: 3230664656192739124, guid: 2b1144a24b50f0d4dbb27a4242da1a01, type: 3}
+  m_PrefabInstance: {fileID: 80485037}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1243176259
 GameObject:
   m_ObjectHideFlags: 0
@@ -539,6 +469,17 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1302529984 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1075189731071507310, guid: 407827aefabc9bb4aa8c747fcf7f977c, type: 3}
+  m_PrefabInstance: {fileID: 690380120}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fd9b56c680b758e44a7ece4d30fbc1d5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::CellHighlight
 --- !u!1001 &1394565029
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -547,14 +488,98 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 651773196946485032, guid: 0d421f50ae089d34aa77d042e4fae853, type: 3}
+      propertyPath: summonUnit
+      value: 
+      objectReference: {fileID: 2058181463}
+    - target: {fileID: 3586491415078184626, guid: 0d421f50ae089d34aa77d042e4fae853, type: 3}
+      propertyPath: _combineSO
+      value: 
+      objectReference: {fileID: 11400000, guid: 0dfded2c1c40dd54498084b03b040f27, type: 2}
+    - target: {fileID: 3586491415078184626, guid: 0d421f50ae089d34aa77d042e4fae853, type: 3}
+      propertyPath: _synergyManager
+      value: 
+      objectReference: {fileID: 2058181465}
     - target: {fileID: 4351018382781704222, guid: 0d421f50ae089d34aa77d042e4fae853, type: 3}
       propertyPath: m_Name
       value: GameManager
       objectReference: {fileID: 0}
+    - target: {fileID: 8423151259897990698, guid: 0d421f50ae089d34aa77d042e4fae853, type: 3}
+      propertyPath: _synergyManager
+      value: 
+      objectReference: {fileID: 2058181465}
     - target: {fileID: 8554172300313096461, guid: 0d421f50ae089d34aa77d042e4fae853, type: 3}
       propertyPath: boardSystem
       value: 
       objectReference: {fileID: 95619001}
+    - target: {fileID: 8554172300313096461, guid: 0d421f50ae089d34aa77d042e4fae853, type: 3}
+      propertyPath: worldCamera
+      value: 
+      objectReference: {fileID: 950284288}
+    - target: {fileID: 8554172300313096461, guid: 0d421f50ae089d34aa77d042e4fae853, type: 3}
+      propertyPath: cellHighlight
+      value: 
+      objectReference: {fileID: 1302529984}
+    - target: {fileID: 8554172300313096461, guid: 0d421f50ae089d34aa77d042e4fae853, type: 3}
+      propertyPath: 'unitPrefabTable.Array.data[0]'
+      value: 
+      objectReference: {fileID: 244802476185505501, guid: c1aad0cdb6b11744fbee5a319d3286ad, type: 3}
+    - target: {fileID: 8554172300313096461, guid: 0d421f50ae089d34aa77d042e4fae853, type: 3}
+      propertyPath: 'unitPrefabTable.Array.data[1]'
+      value: 
+      objectReference: {fileID: 3402729233119560945, guid: 3ce48dc4e8190124796aa529457e8f59, type: 3}
+    - target: {fileID: 8554172300313096461, guid: 0d421f50ae089d34aa77d042e4fae853, type: 3}
+      propertyPath: 'unitPrefabTable.Array.data[2]'
+      value: 
+      objectReference: {fileID: 4022017438092791276, guid: 1d189ead7db93144d8294940b246c2f7, type: 3}
+    - target: {fileID: 8554172300313096461, guid: 0d421f50ae089d34aa77d042e4fae853, type: 3}
+      propertyPath: 'unitPrefabTable.Array.data[3]'
+      value: 
+      objectReference: {fileID: 4758709966895826608, guid: d78deba55693d0f46be5f4a3dfe1587e, type: 3}
+    - target: {fileID: 8554172300313096461, guid: 0d421f50ae089d34aa77d042e4fae853, type: 3}
+      propertyPath: 'unitPrefabTable.Array.data[4]'
+      value: 
+      objectReference: {fileID: 3845496828883880324, guid: 53c770a7910ee5b43b124010835a8ba9, type: 3}
+    - target: {fileID: 8554172300313096461, guid: 0d421f50ae089d34aa77d042e4fae853, type: 3}
+      propertyPath: 'unitPrefabTable.Array.data[5]'
+      value: 
+      objectReference: {fileID: 2426415389849136841, guid: a39f68dbc83ea72428e8103b02a94649, type: 3}
+    - target: {fileID: 8554172300313096461, guid: 0d421f50ae089d34aa77d042e4fae853, type: 3}
+      propertyPath: 'unitPrefabTable.Array.data[6]'
+      value: 
+      objectReference: {fileID: 2503578839737141156, guid: eb8306bedff8d5d4eb667e33bc8b720c, type: 3}
+    - target: {fileID: 8554172300313096461, guid: 0d421f50ae089d34aa77d042e4fae853, type: 3}
+      propertyPath: 'unitPrefabTable.Array.data[7]'
+      value: 
+      objectReference: {fileID: 6438905527573206805, guid: 98bd86ebde9d225418243c9108fcf033, type: 3}
+    - target: {fileID: 8554172300313096461, guid: 0d421f50ae089d34aa77d042e4fae853, type: 3}
+      propertyPath: 'unitPrefabTable.Array.data[8]'
+      value: 
+      objectReference: {fileID: 4520962327849263385, guid: 20439fba87fc49f4284e8fa554c2e6ea, type: 3}
+    - target: {fileID: 8554172300313096461, guid: 0d421f50ae089d34aa77d042e4fae853, type: 3}
+      propertyPath: 'unitPrefabTable.Array.data[9]'
+      value: 
+      objectReference: {fileID: 4693551505388254126, guid: 89123e1b24d937449bc9c078a101d732, type: 3}
+    - target: {fileID: 8554172300313096461, guid: 0d421f50ae089d34aa77d042e4fae853, type: 3}
+      propertyPath: 'unitPrefabTable.Array.data[10]'
+      value: 
+      objectReference: {fileID: 2376804467769598053, guid: 8226eb8ac9b7ed5428047f69529caa68, type: 3}
+    - target: {fileID: 8554172300313096461, guid: 0d421f50ae089d34aa77d042e4fae853, type: 3}
+      propertyPath: 'unitPrefabTable.Array.data[11]'
+      value: 
+      objectReference: {fileID: 3406721906797385192, guid: ceb274333da33af42af63de7d0d4fc9d, type: 3}
+    - target: {fileID: 8554172300313096461, guid: 0d421f50ae089d34aa77d042e4fae853, type: 3}
+      propertyPath: 'unitPrefabTable.Array.data[12]'
+      value: 
+      objectReference: {fileID: 540444489045863749, guid: bf33c3f00b0d5ad46b463024b3da7a69, type: 3}
+    - target: {fileID: 8554172300313096461, guid: 0d421f50ae089d34aa77d042e4fae853, type: 3}
+      propertyPath: 'unitPrefabTable.Array.data[13]'
+      value: 
+      objectReference: {fileID: 4077702490002813465, guid: abe93491d00c8054fa2a982cc29ca319, type: 3}
+    - target: {fileID: 8554172300313096461, guid: 0d421f50ae089d34aa77d042e4fae853, type: 3}
+      propertyPath: 'unitPrefabTable.Array.data[14]'
+      value: 
+      objectReference: {fileID: 2528165396881810678, guid: bc98b0a1a008fe24e80eaaa8a63b41d6, type: 3}
     - target: {fileID: 8821340008124069095, guid: 0d421f50ae089d34aa77d042e4fae853, type: 3}
       propertyPath: m_LocalPosition.x
       value: 629.9414
@@ -598,14 +623,17 @@ PrefabInstance:
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
-    m_AddedComponents: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 4351018382781704222, guid: 0d421f50ae089d34aa77d042e4fae853, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 2058181469}
   m_SourcePrefab: {fileID: 100100000, guid: 0d421f50ae089d34aa77d042e4fae853, type: 3}
 --- !u!114 &1394565034 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 651773196946485032, guid: 0d421f50ae089d34aa77d042e4fae853, type: 3}
   m_PrefabInstance: {fileID: 1394565029}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
+  m_GameObject: {fileID: 2058181462}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 828684002203c9f44b0b24e6e4bcd2be, type: 3}
@@ -735,108 +763,49 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: e0adf817a5497514a851ac63e5d6d0c0, type: 3}
---- !u!1 &2004171401
+--- !u!1 &2058181462 stripped
 GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 4351018382781704222, guid: 0d421f50ae089d34aa77d042e4fae853, type: 3}
+  m_PrefabInstance: {fileID: 1394565029}
   m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2004171405}
-  - component: {fileID: 2004171404}
-  - component: {fileID: 2004171403}
-  - component: {fileID: 2004171402}
-  m_Layer: 5
-  m_Name: Canvas
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &2004171402
+--- !u!114 &2058181463 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8554172300313096461, guid: 0d421f50ae089d34aa77d042e4fae853, type: 3}
+  m_PrefabInstance: {fileID: 1394565029}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2058181462}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 941f1af0371aca84eb9a91411a86a501, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::SummonUnit
+--- !u!114 &2058181465 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8140035803927745397, guid: 0d421f50ae089d34aa77d042e4fae853, type: 3}
+  m_PrefabInstance: {fileID: 1394565029}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2058181462}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8671bf31c6f0649468d77bb3be8925bb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::SynergyManager
+--- !u!114 &2058181469
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2004171401}
+  m_GameObject: {fileID: 2058181462}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Script: {fileID: 11500000, guid: 3ad1b08b79f9ca14382a331f416dfafa, type: 3}
   m_Name: 
-  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.GraphicRaycaster
-  m_IgnoreReversedGraphics: 1
-  m_BlockingObjects: 0
-  m_BlockingMask:
+  m_EditorClassIdentifier: Assembly-CSharp::UnitPointerInputRouter
+  worldCamera: {fileID: 950284288}
+  unitLayer:
     serializedVersion: 2
-    m_Bits: 4294967295
---- !u!114 &2004171403
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2004171401}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.CanvasScaler
-  m_UiScaleMode: 0
-  m_ReferencePixelsPerUnit: 100
-  m_ScaleFactor: 1
-  m_ReferenceResolution: {x: 800, y: 600}
-  m_ScreenMatchMode: 0
-  m_MatchWidthOrHeight: 0
-  m_PhysicalUnit: 3
-  m_FallbackScreenDPI: 96
-  m_DefaultSpriteDPI: 96
-  m_DynamicPixelsPerUnit: 1
-  m_PresetInfoIsWorld: 0
---- !u!223 &2004171404
-Canvas:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2004171401}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_RenderMode: 0
-  m_Camera: {fileID: 0}
-  m_PlaneDistance: 100
-  m_PixelPerfect: 0
-  m_ReceivesEvents: 1
-  m_OverrideSorting: 0
-  m_OverridePixelPerfect: 0
-  m_SortingBucketNormalizedSize: 0
-  m_VertexColorAlwaysGammaSpace: 0
-  m_AdditionalShaderChannelsFlag: 25
-  m_UpdateRectTransformForStandalone: 0
-  m_SortingLayerID: 0
-  m_SortingOrder: 0
-  m_TargetDisplay: 0
---- !u!224 &2004171405
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2004171401}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0, y: 0, z: 0}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 88782408}
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0, y: 0}
+    m_Bits: 8224
 --- !u!1001 &2281827228721750624
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1025,8 +994,8 @@ SceneRoots:
   - {fileID: 1834009732}
   - {fileID: 1855282734}
   - {fileID: 2281827228721750624}
-  - {fileID: 2004171405}
   - {fileID: 1243176262}
   - {fileID: 5215276384406038830}
   - {fileID: 690380120}
   - {fileID: 3755270939970587929}
+  - {fileID: 496014318}

--- a/Bismuth/Assets/Scripts/이수형/BoardSystem/BoardSystem.cs
+++ b/Bismuth/Assets/Scripts/이수형/BoardSystem/BoardSystem.cs
@@ -309,6 +309,7 @@ public class BoardSystem : MonoBehaviour
         }
 
         PlacementSlot[] slots = placementSlotRoot.GetComponentsInChildren<PlacementSlot>(true);
+        List<SlotData> emptySlots = new List<SlotData>();
 
         foreach (PlacementSlot slot in slots)
         {
@@ -320,11 +321,15 @@ public class BoardSystem : MonoBehaviour
 
             if (!slotData.isOccupied)
             {
-                emptySlot = slotData;
-                return true;
+                emptySlots.Add(slotData);
+                continue;
+                
             }
         }
+        int randomIndex = Random.Range(0, emptySlots.Count);
 
-        return false;
+        emptySlot = emptySlots[randomIndex];
+
+        return true;
     }
 }

--- a/Bismuth/Assets/Scripts/이수형/BoardSystem/TowerLongPressDragHandler.cs
+++ b/Bismuth/Assets/Scripts/이수형/BoardSystem/TowerLongPressDragHandler.cs
@@ -1,5 +1,5 @@
 using UnityEngine;
-using UnityEngine.EventSystems;
+
 
 [DisallowMultipleComponent]
 [RequireComponent(typeof(TowerUnit))]
@@ -21,6 +21,12 @@ public class TowerLongPressDragHandler : MonoBehaviour
     private Vector2 pressedScreenPos;
     private Vector3 dragOffset;
 
+    public void Initialize(BoardSystem board, Camera cam, CellHighlight highlight)
+    {
+        boardSystem = board;
+        worldCamera = cam;
+        cellHighlight = highlight;
+    }
     private void Awake()
     {
         towerUnit = GetComponent<TowerUnit>();
@@ -64,22 +70,40 @@ public class TowerLongPressDragHandler : MonoBehaviour
 
         UpdateDrag();
     }
-
-    private void OnMouseDown()
+    public bool BeginPress(Vector2 screenPos)
     {
-        if (towerUnit == null || towerUnit.CurrentSlot == null)
-            return;
+        if (isActiveAndEnabled == false)
+            return false;
+        if (towerUnit == null || towerUnit.CurrentSlot == null) 
+            return false;
 
-        if (EventSystem.current != null && EventSystem.current.IsPointerOverGameObject())
-            return;
+
+        
 
         isPressed = true;
         isDragging = false;
         pressedTime = Time.time;
-        pressedScreenPos = Input.mousePosition;
+        pressedScreenPos = screenPos;
 
         DebugTool.Log("타워 홀드 시작", DebugType.Unit, this);
+        return true;
     }
+    //private void OnMouseDown()
+    //{
+    //    DebugTool.Log("타워 홀드 마우스인식", DebugType.Unit, this);
+    //    if (towerUnit == null || towerUnit.CurrentSlot == null)
+    //        return;
+
+    //    if (EventSystem.current != null && EventSystem.current.IsPointerOverGameObject())
+    //        return;
+
+    //    isPressed = true;
+    //    isDragging = false;
+    //    pressedTime = Time.time;
+    //    pressedScreenPos = Input.mousePosition;
+
+    //    DebugTool.Log("타워 홀드 시작", DebugType.Unit, this);
+    //}
 
     private void BeginDrag()
     {
@@ -233,4 +257,6 @@ public class TowerLongPressDragHandler : MonoBehaviour
 
         ResetState();
     }
+
+    
 }

--- a/Bismuth/Assets/Scripts/이수형/BoardSystem/UnitInputRouter.cs
+++ b/Bismuth/Assets/Scripts/이수형/BoardSystem/UnitInputRouter.cs
@@ -1,0 +1,77 @@
+using UnityEngine;
+using UnityEngine.EventSystems;
+
+[DisallowMultipleComponent]
+public class UnitPointerInputRouter : MonoBehaviour
+{
+    [Header("References")]
+    [SerializeField] private Camera worldCamera;
+
+    [Header("Layers")]
+    [SerializeField] private LayerMask unitLayer;
+
+    private void Awake()
+    {
+        if (worldCamera == null)
+            worldCamera = Camera.main;
+    }
+
+    private void Update()
+    {
+        if (!Input.GetMouseButtonDown(0))
+            return;
+
+        if (EventSystem.current != null && EventSystem.current.IsPointerOverGameObject())
+        {
+            DebugTool.Log("유닛 입력 무시 - UI 위 클릭", DebugType.Unit, this);
+            return;
+        }
+
+        Vector3 mouseWorld = GetMouseWorld();
+
+        Collider2D hit = Physics2D.OverlapPoint(mouseWorld, unitLayer);
+        if (hit == null)
+            return;
+
+        TowerLongPressDragHandler dragHandler = hit.GetComponent<TowerLongPressDragHandler>();
+        if (dragHandler == null)
+            dragHandler = hit.GetComponentInParent<TowerLongPressDragHandler>();
+
+        if (dragHandler == null)
+        {
+            DebugTool.Warnning(
+                $"Unit 레이어 클릭 대상에 TowerLongPressDragHandler가 없습니다. target={hit.name}",
+                DebugType.Unit,
+                this
+            );
+            return;
+        }
+
+        bool started = dragHandler.BeginPress((Vector2)Input.mousePosition);
+        if (started)
+        {
+            DebugTool.Log(
+                $"유닛 홀드 입력 라우팅 성공 - target={hit.name}",
+                DebugType.Unit,
+                this
+            );
+        }
+    }
+
+    private Vector3 GetMouseWorld()
+    {
+        if (worldCamera == null)
+            worldCamera = Camera.main;
+
+        if (worldCamera == null)
+            return Vector3.zero;
+
+        float zDistance = -worldCamera.transform.position.z;
+        Vector3 worldPos = worldCamera.ScreenToWorldPoint(
+            new Vector3(Input.mousePosition.x, Input.mousePosition.y, zDistance)
+        );
+
+        worldPos.z = 0f;
+        return worldPos;
+    }
+}

--- a/Bismuth/Assets/Scripts/이수형/BoardSystem/UnitInputRouter.cs.meta
+++ b/Bismuth/Assets/Scripts/이수형/BoardSystem/UnitInputRouter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3ad1b08b79f9ca14382a331f416dfafa

--- a/Bismuth/Assets/Scripts/이수형/Unit/Summon Unit.cs
+++ b/Bismuth/Assets/Scripts/이수형/Unit/Summon Unit.cs
@@ -40,6 +40,9 @@ public class SummonUnit : MonoBehaviour
     [SerializeField] private BoardSystem boardSystem;
     [SerializeField] private SynergyManager synergyManager;
     [SerializeField] private PlayerDataManager playerDataManager;
+    [SerializeField] private CellHighlight cellHighlight;
+    [SerializeField] private Camera worldCamera;
+     
 
     [Header("Data")]
     [SerializeField] private List<UnitSO> units = new List<UnitSO>(4);
@@ -68,7 +71,12 @@ public class SummonUnit : MonoBehaviour
         if (playerDataManager == null)
             playerDataManager = GetComponent<PlayerDataManager>();
 
-        
+        if (cellHighlight == null)
+            cellHighlight = FindAnyObjectByType<CellHighlight>();
+        if (worldCamera == null)
+            worldCamera = Camera.main;
+
+
         // BuildPrefabMap();
     }
 
@@ -285,8 +293,16 @@ public class SummonUnit : MonoBehaviour
 
         unit.gameObject.name = data.Id.ToString();
 
-        if (unit.GetComponent<TowerLongPressDragHandler>() == null)
-            unit.gameObject.AddComponent<TowerLongPressDragHandler>();
+        TowerLongPressDragHandler dragHandler = unit.GetComponent<TowerLongPressDragHandler>();
+
+
+        //if (unit.GetComponent<TowerLongPressDragHandler>() == null)
+        //    unit.gameObject.AddComponent<TowerLongPressDragHandler>();
+
+        if (dragHandler == null)
+            dragHandler = unit.gameObject.AddComponent<TowerLongPressDragHandler>();
+
+        dragHandler.Initialize(boardSystem, worldCamera, cellHighlight);
     }
 
     private UnitStat ApplyUnitStat(GameObject unitObject, UnitData unitData)


### PR DESCRIPTION

타워 랜덤배치 적용되도록 픽스

유닛 선택이 제대로 안되는 버그 픽스:

OnMouseDown() 함수에서 버그발생 -> 콜라이더가 겹쳐있을 경우(유닛 + PlacementSlot) 우선순위가 없어 랜덤하게 선택을 하게 되어 문제 발생
--> OnMouseDown() 대신 마우스 클릭 시에 설정한 레이어(GameManager에 붙은 UnitInputRouter.cs 컴포넌트에서 선택 가능)를 가지고 있고, TowerLongPressDragHolder 를 가지고 있는 물체를 인식.


주의사항 또는 참고사항:
- 기존 GameManager Prefab에 Scripts/이수형/BoardSystem/UnitInputRouter 를 붙여야 한다. Layer는 일단은 UI로 설정 

<img width="774" height="438" alt="image" src="https://github.com/user-attachments/assets/90469254-6be1-4fbb-a1c4-653cb9ae5db5" />

- GameManager에 UnitInputRouter 컴포넌트에서 Unit을 고르면 작동하지 않는다. 현재 유닛 프리팝들은 이미지와 같이 레이어가 UI로 되어있기 때문...

- 인식범위는 유닛 프리팹의 콜라이더와 공유한다. 지금은 box collider를 씌운 채로 2*2 타일과 범위가 일치한다. 이건 수작업으로 collider를 바꿔야 할 수도...

- Stage1 씬에서 UI canvas 까지 적용했으니 GameManager 설정이 기억안나면 참고