### PR TITLE
[fix]웨이브당 몬스터 체력 증가식 오적용 픽스

### DIFF
--- a/Bismuth/Assets/Scripts/이상현/Monster/Spawning/MonsterRuntimeValueCalculator.cs
+++ b/Bismuth/Assets/Scripts/이상현/Monster/Spawning/MonsterRuntimeValueCalculator.cs
@@ -38,7 +38,7 @@ public static class MonsterRuntimeValueCalculator
         int growthWave = GetGrowthWave(monsterData.Category, waveNumber);
 
         float finalHp =
-            (monsterData.HpGrowth * growthWave * growthWave + monsterData.BaseHp)
+            (monsterData.HpGrowth * growthWave + monsterData.BaseHp)
             * difficultyModifier.EnemyHpMultiplier;
 
         return Mathf.RoundToInt(finalHp);


### PR DESCRIPTION
[웨이브당 몬스터 체력 증가식 오적용 픽스]
- finalHp = (monsterData.HpGrowth * growthWave * growthWave + monsterData.BaseHp) * difficultyModifier.EnemyHpMultiplier
->  finalHp = (monsterData.HpGrowth * growthWave + monsterData.BaseHp) * difficultyModifier.EnemyHpMultiplier