### PR TITLE
[feat] 슬로우 및 오크 버프 시 색상필터 적용 + 오크 시너지 구현

### DIFF
--- a/Bismuth/Assets/Scripts/이상현/Monster/Core/MonsterMover.cs
+++ b/Bismuth/Assets/Scripts/이상현/Monster/Core/MonsterMover.cs
@@ -20,6 +20,9 @@ public class MonsterMover : MonoBehaviour
     private bool _isPathCompleted;
     private bool _isSlowed;
 
+    private SpriteColorTint _colorTint;
+    private static readonly Color SlowTintColor = new Color(0.5f, 0.5f, 1f, 1f);
+
     public bool IsMoving { get; private set; }
     public Vector2 MoveDirection { get; private set; }
     public bool IsSlowed => _isSlowed;
@@ -46,6 +49,7 @@ public class MonsterMover : MonoBehaviour
         _isInitialized = false;
         _isPathCompleted = false;
         _isSlowed = false;
+        _colorTint?.Remove();
     }
 
     private void FixedUpdate()
@@ -90,7 +94,7 @@ public class MonsterMover : MonoBehaviour
         transform.position = startPosition;
 
         _isInitialized = true;
-
+        _colorTint = new SpriteColorTint(gameObject);
 
         if (_path.WaypointCount <= 1) CompletePath();
     }
@@ -104,6 +108,7 @@ public class MonsterMover : MonoBehaviour
         float clampedPercent = Mathf.Clamp(percent, 0f, 100f);
         _moveSpeed = _baseSpeed * (1f - clampedPercent * 0.01f);
         _isSlowed = true;
+        _colorTint?.Apply(SlowTintColor);
 
         DebugTool.Log(
             $"이동속도 감소 적용 | base={_baseSpeed:F2}, slow={clampedPercent:F1}%, current={_moveSpeed:F2}",
@@ -118,6 +123,7 @@ public class MonsterMover : MonoBehaviour
 
         _moveSpeed = _baseSpeed;
         _isSlowed = false;
+        _colorTint?.Remove();
 
         DebugTool.Log(
             $"이동속도 감소 해제 | 복원 속도={_baseSpeed:F2}",

--- a/Bismuth/Assets/Scripts/이수형/Combat/AttackContext.cs
+++ b/Bismuth/Assets/Scripts/이수형/Combat/AttackContext.cs
@@ -1,34 +1,32 @@
 
-// 공격 한 번의 맥락을 담는 구조체.
-// bool 파라미터 나열 대신 이 구조체 하나를 전달한다.
 
 public struct AttackContext
 {
-    // 일반 공격(평타)인지 여부. false면 시너지 추가타 등 스킬 공격이다. 
+
     public bool IsNormalAttack;
 
-    // 전사 시너지 추가타 여부 
+
     public bool IsWarriorBonus;
 
-    // 마법사 시너지 추가 대미지 여부 
+
     public bool IsWizardBonus;
 
-    // 궁수 시너지 강화 공격 여부 
+
     public bool IsArcherBonus;
 
-    // 수인 시너지 추가타 여부 (Step 3에서 사용) 
+
     public bool IsFurryBonus;
 
-    // 애니메이션 배속 배율. 기본=1, 수인 추가타=N 
+
     public float AnimSpeedMultiplier;
 
-    // 기본 일반공격 컨텍스트를 생성한다.
+
     public static AttackContext Normal()
     {
         return new AttackContext { IsNormalAttack = true, AnimSpeedMultiplier = 1f };
     }
 
-    // 시너지 스택 적립 대상인지 판별한다. 일반공격만 적립 대상이다. 
+
     public bool CountsForSynergyStacks => IsNormalAttack && !IsWarriorBonus && !IsFurryBonus;
 
     public override string ToString()
@@ -38,7 +36,7 @@ public struct AttackContext
 }
 
 
-// 추가 공격의 종류를 구분하는 열거형.
+
 
 public enum ExtraAttackType
 {
@@ -47,24 +45,23 @@ public enum ExtraAttackType
 }
 
 
-// 대기 중인 추가 공격 배치 하나를 표현한다.
-// 큐에 넣어 순서대로 처리한다.
+
 
 public struct PendingExtraAttack
 {
-    // 추가 공격 종류 
+
     public ExtraAttackType Type;
 
-    // 이 배치에서 남은 공격 횟수 
+
     public int RemainingCount;
 
-    // 강제 타겟. null이면 센서에서 가장 가까운 적을 사용한다.
+
     public MonsterController ForcedTarget;
 
-    // 애니메이션 배속 배율. 전사=1, 수인=추가타 횟수 
+
     public float AnimSpeedMultiplier;
 
-    // 이 배치가 아직 처리할 공격이 남아있는지 
+
     public bool HasRemaining => RemainingCount > 0;
 
     public override string ToString()

--- a/Bismuth/Assets/Scripts/이수형/Combat/CombatManager.cs
+++ b/Bismuth/Assets/Scripts/이수형/Combat/CombatManager.cs
@@ -58,6 +58,21 @@ public class CombatManager : MonoBehaviour
     private readonly List<MonsterMover> _slowedMonsters = new();
     private bool _isSpiritActive;
 
+    [Header("Orc Synergy")]
+    [SerializeField, Min(0.1f)] private float orcCooldown = 10f;
+    [SerializeField] private bool orcSynergyLog = false;
+
+    private Coroutine _orcRoutine;
+    private readonly List<SpriteColorTint> _orcTintedUnits = new();
+    private bool _isOrcActive;
+    private bool _isOrcBuffActive;
+    private bool _isWaveActive;
+    private float _orcBuffPercent;
+    private static readonly Color OrcBuffTintColor = new Color(1f, 0.5f, 0.5f, 1f);
+
+    public bool IsOrcBuffActive => _isOrcBuffActive;
+    public float OrcBuffPercent => _orcBuffPercent;
+
     private Collider2D[] aoeOverlapResults;
 
     private void Awake()
@@ -91,17 +106,23 @@ public class CombatManager : MonoBehaviour
             synergyManager = gameManager.GetComponent<SynergyManager>();
         if (_battleWaveRunner == null)
             _battleWaveRunner = FindFirstObjectByType<BattleWaveRunner>();
-        if(playerDataManager == null)
+        if (playerDataManager == null)
             playerDataManager = FindFirstObjectByType<PlayerDataManager>();
     }
 
     private void OnEnable()
     {
         if (_battleWaveRunner != null)
+        {
             _battleWaveRunner.WaveStarted += OnWaveStarted;
+            _battleWaveRunner.WaveCleared += OnWaveCleared;
+        }
 
         if (synergyManager != null)
             synergyManager.OnSynergyChanged += HandleSynergyChangedForSpirit;
+
+        if (synergyManager != null)
+            synergyManager.OnSynergyChanged += HandleSynergyChangedForOrc;
     }
 
     private void Start()
@@ -112,7 +133,13 @@ public class CombatManager : MonoBehaviour
     private void OnDisable()
     {
         if (_battleWaveRunner != null)
+        {
             _battleWaveRunner.WaveStarted -= OnWaveStarted;
+            _battleWaveRunner.WaveCleared -= OnWaveCleared;
+        }
+
+        if (synergyManager != null)
+            synergyManager.OnSynergyChanged -= HandleSynergyChangedForOrc;
     }
 
     private void OnValidate()
@@ -496,7 +523,7 @@ public class CombatManager : MonoBehaviour
 
             if (HasSynergyTag(unitStat, (int)SynergyManager.SynergyType.Elf))
             {
-                if(unitStat.ElfWaveKillCount < 10)
+                if (unitStat.ElfWaveKillCount < 10)
                     unitStat.ElfWaveKillCount++;
                 DebugTool.Log(
                     $"엘프 웨이브 킬 적립 | source={sourceName}, elfKill={unitStat.ElfWaveKillCount}",
@@ -526,7 +553,7 @@ public class CombatManager : MonoBehaviour
 
 
         int activeCount = synergyManager.GetSynergyLevel((int)SynergyManager.SynergyType.Human);
-        
+
         Debug.Log(
             $"인간 시너지 레벨 조회 | activeCount={activeCount}"
         );
@@ -906,6 +933,34 @@ public class CombatManager : MonoBehaviour
     private void OnWaveStarted(WaveDataSO waveData)
     {
         ResetAllElfWaveKillCounts();
+
+        _isWaveActive = true;
+
+  
+        if (_isOrcActive && _orcRoutine == null)
+        {
+            _orcRoutine = StartCoroutine(OrcSynergyRoutine());
+
+            if (orcSynergyLog)
+                DebugTool.Log("오크 시너지 버프 사이클 시작 | 웨이브 시작", DebugType.Synergy, this);
+        }
+    }
+
+    private void OnWaveCleared(WaveDataSO waveData)
+    {
+        _isWaveActive = false;
+
+
+        if (_orcRoutine != null)
+        {
+            StopCoroutine(_orcRoutine);
+            _orcRoutine = null;
+        }
+
+        RemoveOrcBuff();
+
+        if (orcSynergyLog)
+            DebugTool.Log("오크 시너지 버프 해제 및 쿨타임 초기화 | 웨이브 클리어", DebugType.Synergy, this);
     }
 
     private void ResetAllElfWaveKillCounts()
@@ -1111,5 +1166,189 @@ public class CombatManager : MonoBehaviour
             return int.MaxValue;
 
         return spiritData.Levels[0].ActiveCount;
+    }
+
+
+
+    private void HandleSynergyChangedForOrc(Dictionary<int, List<int>> synergiesDict)
+    {
+        const int orcId = (int)SynergyManager.SynergyType.Orc;
+
+        bool shouldBeActive = synergiesDict.ContainsKey(orcId)
+                              && synergiesDict[orcId].Count >= GetOrcMinActiveCount();
+
+        if (shouldBeActive && !_isOrcActive)
+        {
+            StartOrcSynergy();
+        }
+        else if (!shouldBeActive && _isOrcActive)
+        {
+            StopOrcSynergy();
+        }
+    }
+
+    private void StartOrcSynergy()
+    {
+        if (_isOrcActive)
+            return;
+
+        _isOrcActive = true;
+
+
+        if (_isWaveActive)
+        {
+            _orcRoutine = StartCoroutine(OrcSynergyRoutine());
+            DebugTool.Log("오크 시너지 활성화 | 버프 사이클 즉시 시작", DebugType.Synergy, this);
+        }
+        else
+        {
+            DebugTool.Log("오크 시너지 활성화 | 정비시간이므로 웨이브 시작 시 발동 예정", DebugType.Synergy, this);
+        }
+    }
+
+    private void StopOrcSynergy()
+    {
+        if (!_isOrcActive)
+            return;
+
+        _isOrcActive = false;
+
+        if (_orcRoutine != null)
+        {
+            StopCoroutine(_orcRoutine);
+            _orcRoutine = null;
+        }
+
+        RemoveOrcBuff();
+
+        DebugTool.Log("오크 시너지 비활성화 | 버프 해제 및 사이클 중단", DebugType.Synergy, this);
+    }
+
+    private IEnumerator OrcSynergyRoutine()
+    {
+        while (_isOrcActive && _isWaveActive)
+        {
+            if (!TryGetOrcEffectValues(out float duration, out float attackPercent))
+            {
+                if (orcSynergyLog)
+                    DebugTool.Log("오크 시너지 효과값 조회 실패 | 다음 쿨다운 대기", DebugType.Synergy, this);
+
+                yield return new WaitForSeconds(orcCooldown);
+                continue;
+            }
+
+
+            ApplyOrcBuff(attackPercent);
+
+            if (orcSynergyLog)
+                DebugTool.Log(
+                    $"오크 시너지 발동 | attackBonus={attackPercent:F1}%, duration={duration:F1}s",
+                    DebugType.Synergy, this);
+
+            yield return new WaitForSeconds(duration);
+
+
+            RemoveOrcBuff();
+
+            if (orcSynergyLog)
+                DebugTool.Log("오크 시너지 버프 해제 | 쿨다운 재시작", DebugType.Synergy, this);
+
+            yield return new WaitForSeconds(orcCooldown);
+
+            if (!_isOrcActive || !_isWaveActive)
+                yield break;
+        }
+    }
+
+    private bool TryGetOrcEffectValues(out float duration, out float attackPercent)
+    {
+        duration = 0f;
+        attackPercent = 0f;
+
+        if (synergySO == null || synergyManager == null)
+            return false;
+
+        const int orcId = (int)SynergyManager.SynergyType.Orc;
+
+        SynergyData orcData = GetSynergyData(orcId);
+        if (orcData == null || orcData.Levels == null || orcData.Levels.Count == 0)
+            return false;
+
+        int activeCount = synergyManager.GetSynergyLevel(orcId);
+
+        SynergyLevelData matchedLevel = null;
+        for (int i = 0; i < orcData.Levels.Count; i++)
+        {
+            SynergyLevelData level = orcData.Levels[i];
+            if (level == null)
+                continue;
+
+            if (activeCount < level.ActiveCount)
+                continue;
+
+            matchedLevel = level;
+        }
+
+        if (matchedLevel == null || matchedLevel.EffectValues == null || matchedLevel.EffectValues.Count == 0)
+            return false;
+
+        attackPercent = matchedLevel.EffectValues[0];
+        duration = 5f;
+        return true;
+    }
+
+    private void ApplyOrcBuff(float attackPercent)
+    {
+        _orcBuffPercent = attackPercent;
+        _isOrcBuffActive = true;
+        _orcTintedUnits.Clear();
+
+        const int orcId = (int)SynergyManager.SynergyType.Orc;
+        UnitStat[] allUnits = FindObjectsByType<UnitStat>(FindObjectsSortMode.None);
+
+        for (int i = 0; i < allUnits.Length; i++)
+        {
+            if (!HasSynergyTag(allUnits[i], orcId))
+                continue;
+
+            SpriteColorTint tint = new SpriteColorTint(allUnits[i].gameObject);
+            tint.Apply(OrcBuffTintColor);
+            _orcTintedUnits.Add(tint);
+        }
+
+        if (orcSynergyLog)
+            DebugTool.Log(
+                $"오크 버프 적용 | percent={attackPercent:F1}%, tintedUnits={_orcTintedUnits.Count}",
+                DebugType.Synergy, this);
+    }
+
+    private void RemoveOrcBuff()
+    {
+        _isOrcBuffActive = false;
+        _orcBuffPercent = 0f;
+
+        for (int i = 0; i < _orcTintedUnits.Count; i++)
+        {
+            _orcTintedUnits[i]?.Remove();
+        }
+
+        _orcTintedUnits.Clear();
+
+        if (orcSynergyLog)
+            DebugTool.Log("오크 버프 해제 | 틴트 제거 완료", DebugType.Synergy, this);
+    }
+
+    private int GetOrcMinActiveCount()
+    {
+        if (synergySO == null)
+            return int.MaxValue;
+
+        const int orcId = (int)SynergyManager.SynergyType.Orc;
+        SynergyData orcData = GetSynergyData(orcId);
+
+        if (orcData == null || orcData.Levels == null || orcData.Levels.Count == 0)
+            return int.MaxValue;
+
+        return orcData.Levels[0].ActiveCount;
     }
 }

--- a/Bismuth/Assets/Scripts/이수형/Combat/CombatManager.cs
+++ b/Bismuth/Assets/Scripts/이수형/Combat/CombatManager.cs
@@ -73,21 +73,6 @@ public class CombatManager : MonoBehaviour
     public bool IsOrcBuffActive => _isOrcBuffActive;
     public float OrcBuffPercent => _orcBuffPercent;
 
-    [Header("Orc Synergy")]
-    [SerializeField, Min(0.1f)] private float orcCooldown = 10f;
-    [SerializeField] private bool orcSynergyLog = false;
-
-    private Coroutine _orcRoutine;
-    private readonly List<SpriteColorTint> _orcTintedUnits = new();
-    private bool _isOrcActive;
-    private bool _isOrcBuffActive;
-    private bool _isWaveActive;
-    private float _orcBuffPercent;
-    private static readonly Color OrcBuffTintColor = new Color(1f, 0.5f, 0.5f, 1f);
-
-    public bool IsOrcBuffActive => _isOrcBuffActive;
-    public float OrcBuffPercent => _orcBuffPercent;
-
     private Collider2D[] aoeOverlapResults;
 
     private void Awake()
@@ -122,7 +107,6 @@ public class CombatManager : MonoBehaviour
         if (_battleWaveRunner == null)
             _battleWaveRunner = FindFirstObjectByType<BattleWaveRunner>();
         if (playerDataManager == null)
-        if (playerDataManager == null)
             playerDataManager = FindFirstObjectByType<PlayerDataManager>();
     }
 
@@ -130,18 +114,12 @@ public class CombatManager : MonoBehaviour
     {
         if (_battleWaveRunner != null)
         {
-        {
             _battleWaveRunner.WaveStarted += OnWaveStarted;
-            _battleWaveRunner.WaveCleared += OnWaveCleared;
-        }
             _battleWaveRunner.WaveCleared += OnWaveCleared;
         }
 
         if (synergyManager != null)
             synergyManager.OnSynergyChanged += HandleSynergyChangedForSpirit;
-
-        if (synergyManager != null)
-            synergyManager.OnSynergyChanged += HandleSynergyChangedForOrc;
 
         if (synergyManager != null)
             synergyManager.OnSynergyChanged += HandleSynergyChangedForOrc;
@@ -156,13 +134,7 @@ public class CombatManager : MonoBehaviour
     {
         if (_battleWaveRunner != null)
         {
-        {
             _battleWaveRunner.WaveStarted -= OnWaveStarted;
-            _battleWaveRunner.WaveCleared -= OnWaveCleared;
-        }
-
-        if (synergyManager != null)
-            synergyManager.OnSynergyChanged -= HandleSynergyChangedForOrc;
             _battleWaveRunner.WaveCleared -= OnWaveCleared;
         }
 
@@ -552,7 +524,6 @@ public class CombatManager : MonoBehaviour
             if (HasSynergyTag(unitStat, (int)SynergyManager.SynergyType.Elf))
             {
                 if (unitStat.ElfWaveKillCount < 10)
-                if (unitStat.ElfWaveKillCount < 10)
                     unitStat.ElfWaveKillCount++;
                 DebugTool.Log(
                     $"엘프 웨이브 킬 적립 | source={sourceName}, elfKill={unitStat.ElfWaveKillCount}",
@@ -582,7 +553,6 @@ public class CombatManager : MonoBehaviour
 
 
         int activeCount = synergyManager.GetSynergyLevel((int)SynergyManager.SynergyType.Human);
-
 
         Debug.Log(
             $"인간 시너지 레벨 조회 | activeCount={activeCount}"
@@ -966,7 +936,7 @@ public class CombatManager : MonoBehaviour
 
         _isWaveActive = true;
 
-  
+        // 오크 시너지가 활성 상태인데 코루틴이 없으면 시작
         if (_isOrcActive && _orcRoutine == null)
         {
             _orcRoutine = StartCoroutine(OrcSynergyRoutine());
@@ -980,7 +950,7 @@ public class CombatManager : MonoBehaviour
     {
         _isWaveActive = false;
 
-
+        // 오크 버프 즉시 해제 + 코루틴 정지 + 쿨타임 초기화
         if (_orcRoutine != null)
         {
             StopCoroutine(_orcRoutine);
@@ -1224,7 +1194,7 @@ public class CombatManager : MonoBehaviour
 
         _isOrcActive = true;
 
-
+        // 웨이브 진행 중일 때만 코루틴 즉시 시작, 정비시간이면 웨이브 시작 시 시작됨
         if (_isWaveActive)
         {
             _orcRoutine = StartCoroutine(OrcSynergyRoutine());

--- a/Bismuth/Assets/Scripts/이수형/Combat/CombatManager.cs
+++ b/Bismuth/Assets/Scripts/이수형/Combat/CombatManager.cs
@@ -58,6 +58,21 @@ public class CombatManager : MonoBehaviour
     private readonly List<MonsterMover> _slowedMonsters = new();
     private bool _isSpiritActive;
 
+    [Header("Orc Synergy")]
+    [SerializeField, Min(0.1f)] private float orcCooldown = 10f;
+    [SerializeField] private bool orcSynergyLog = false;
+
+    private Coroutine _orcRoutine;
+    private readonly List<SpriteColorTint> _orcTintedUnits = new();
+    private bool _isOrcActive;
+    private bool _isOrcBuffActive;
+    private bool _isWaveActive;
+    private float _orcBuffPercent;
+    private static readonly Color OrcBuffTintColor = new Color(1f, 0.5f, 0.5f, 1f);
+
+    public bool IsOrcBuffActive => _isOrcBuffActive;
+    public float OrcBuffPercent => _orcBuffPercent;
+
     private Collider2D[] aoeOverlapResults;
 
     private void Awake()
@@ -91,17 +106,23 @@ public class CombatManager : MonoBehaviour
             synergyManager = gameManager.GetComponent<SynergyManager>();
         if (_battleWaveRunner == null)
             _battleWaveRunner = FindFirstObjectByType<BattleWaveRunner>();
-        if(playerDataManager == null)
+        if (playerDataManager == null)
             playerDataManager = FindFirstObjectByType<PlayerDataManager>();
     }
 
     private void OnEnable()
     {
         if (_battleWaveRunner != null)
+        {
             _battleWaveRunner.WaveStarted += OnWaveStarted;
+            _battleWaveRunner.WaveCleared += OnWaveCleared;
+        }
 
         if (synergyManager != null)
             synergyManager.OnSynergyChanged += HandleSynergyChangedForSpirit;
+
+        if (synergyManager != null)
+            synergyManager.OnSynergyChanged += HandleSynergyChangedForOrc;
     }
 
     private void Start()
@@ -112,7 +133,13 @@ public class CombatManager : MonoBehaviour
     private void OnDisable()
     {
         if (_battleWaveRunner != null)
+        {
             _battleWaveRunner.WaveStarted -= OnWaveStarted;
+            _battleWaveRunner.WaveCleared -= OnWaveCleared;
+        }
+
+        if (synergyManager != null)
+            synergyManager.OnSynergyChanged -= HandleSynergyChangedForOrc;
     }
 
     private void OnValidate()
@@ -496,7 +523,7 @@ public class CombatManager : MonoBehaviour
 
             if (HasSynergyTag(unitStat, (int)SynergyManager.SynergyType.Elf))
             {
-                if(unitStat.ElfWaveKillCount < 10)
+                if (unitStat.ElfWaveKillCount < 10)
                     unitStat.ElfWaveKillCount++;
                 DebugTool.Log(
                     $"엘프 웨이브 킬 적립 | source={sourceName}, elfKill={unitStat.ElfWaveKillCount}",
@@ -526,7 +553,7 @@ public class CombatManager : MonoBehaviour
 
 
         int activeCount = synergyManager.GetSynergyLevel((int)SynergyManager.SynergyType.Human);
-        
+
         Debug.Log(
             $"인간 시너지 레벨 조회 | activeCount={activeCount}"
         );
@@ -906,6 +933,34 @@ public class CombatManager : MonoBehaviour
     private void OnWaveStarted(WaveDataSO waveData)
     {
         ResetAllElfWaveKillCounts();
+
+        _isWaveActive = true;
+
+        // 오크 시너지가 활성 상태인데 코루틴이 없으면 시작
+        if (_isOrcActive && _orcRoutine == null)
+        {
+            _orcRoutine = StartCoroutine(OrcSynergyRoutine());
+
+            if (orcSynergyLog)
+                DebugTool.Log("오크 시너지 버프 사이클 시작 | 웨이브 시작", DebugType.Synergy, this);
+        }
+    }
+
+    private void OnWaveCleared(WaveDataSO waveData)
+    {
+        _isWaveActive = false;
+
+        // 오크 버프 즉시 해제 + 코루틴 정지 + 쿨타임 초기화
+        if (_orcRoutine != null)
+        {
+            StopCoroutine(_orcRoutine);
+            _orcRoutine = null;
+        }
+
+        RemoveOrcBuff();
+
+        if (orcSynergyLog)
+            DebugTool.Log("오크 시너지 버프 해제 및 쿨타임 초기화 | 웨이브 클리어", DebugType.Synergy, this);
     }
 
     private void ResetAllElfWaveKillCounts()
@@ -1111,5 +1166,189 @@ public class CombatManager : MonoBehaviour
             return int.MaxValue;
 
         return spiritData.Levels[0].ActiveCount;
+    }
+
+
+
+    private void HandleSynergyChangedForOrc(Dictionary<int, List<int>> synergiesDict)
+    {
+        const int orcId = (int)SynergyManager.SynergyType.Orc;
+
+        bool shouldBeActive = synergiesDict.ContainsKey(orcId)
+                              && synergiesDict[orcId].Count >= GetOrcMinActiveCount();
+
+        if (shouldBeActive && !_isOrcActive)
+        {
+            StartOrcSynergy();
+        }
+        else if (!shouldBeActive && _isOrcActive)
+        {
+            StopOrcSynergy();
+        }
+    }
+
+    private void StartOrcSynergy()
+    {
+        if (_isOrcActive)
+            return;
+
+        _isOrcActive = true;
+
+        // 웨이브 진행 중일 때만 코루틴 즉시 시작, 정비시간이면 웨이브 시작 시 시작됨
+        if (_isWaveActive)
+        {
+            _orcRoutine = StartCoroutine(OrcSynergyRoutine());
+            DebugTool.Log("오크 시너지 활성화 | 버프 사이클 즉시 시작", DebugType.Synergy, this);
+        }
+        else
+        {
+            DebugTool.Log("오크 시너지 활성화 | 정비시간이므로 웨이브 시작 시 발동 예정", DebugType.Synergy, this);
+        }
+    }
+
+    private void StopOrcSynergy()
+    {
+        if (!_isOrcActive)
+            return;
+
+        _isOrcActive = false;
+
+        if (_orcRoutine != null)
+        {
+            StopCoroutine(_orcRoutine);
+            _orcRoutine = null;
+        }
+
+        RemoveOrcBuff();
+
+        DebugTool.Log("오크 시너지 비활성화 | 버프 해제 및 사이클 중단", DebugType.Synergy, this);
+    }
+
+    private IEnumerator OrcSynergyRoutine()
+    {
+        while (_isOrcActive && _isWaveActive)
+        {
+            if (!TryGetOrcEffectValues(out float duration, out float attackPercent))
+            {
+                if (orcSynergyLog)
+                    DebugTool.Log("오크 시너지 효과값 조회 실패 | 다음 쿨다운 대기", DebugType.Synergy, this);
+
+                yield return new WaitForSeconds(orcCooldown);
+                continue;
+            }
+
+
+            ApplyOrcBuff(attackPercent);
+
+            if (orcSynergyLog)
+                DebugTool.Log(
+                    $"오크 시너지 발동 | attackBonus={attackPercent:F1}%, duration={duration:F1}s",
+                    DebugType.Synergy, this);
+
+            yield return new WaitForSeconds(duration);
+
+
+            RemoveOrcBuff();
+
+            if (orcSynergyLog)
+                DebugTool.Log("오크 시너지 버프 해제 | 쿨다운 재시작", DebugType.Synergy, this);
+
+            yield return new WaitForSeconds(orcCooldown);
+
+            if (!_isOrcActive || !_isWaveActive)
+                yield break;
+        }
+    }
+
+    private bool TryGetOrcEffectValues(out float duration, out float attackPercent)
+    {
+        duration = 0f;
+        attackPercent = 0f;
+
+        if (synergySO == null || synergyManager == null)
+            return false;
+
+        const int orcId = (int)SynergyManager.SynergyType.Orc;
+
+        SynergyData orcData = GetSynergyData(orcId);
+        if (orcData == null || orcData.Levels == null || orcData.Levels.Count == 0)
+            return false;
+
+        int activeCount = synergyManager.GetSynergyLevel(orcId);
+
+        SynergyLevelData matchedLevel = null;
+        for (int i = 0; i < orcData.Levels.Count; i++)
+        {
+            SynergyLevelData level = orcData.Levels[i];
+            if (level == null)
+                continue;
+
+            if (activeCount < level.ActiveCount)
+                continue;
+
+            matchedLevel = level;
+        }
+
+        if (matchedLevel == null || matchedLevel.EffectValues == null || matchedLevel.EffectValues.Count == 0)
+            return false;
+
+        attackPercent = matchedLevel.EffectValues[0];
+        duration = 5f;
+        return true;
+    }
+
+    private void ApplyOrcBuff(float attackPercent)
+    {
+        _orcBuffPercent = attackPercent;
+        _isOrcBuffActive = true;
+        _orcTintedUnits.Clear();
+
+        const int orcId = (int)SynergyManager.SynergyType.Orc;
+        UnitStat[] allUnits = FindObjectsByType<UnitStat>(FindObjectsSortMode.None);
+
+        for (int i = 0; i < allUnits.Length; i++)
+        {
+            if (!HasSynergyTag(allUnits[i], orcId))
+                continue;
+
+            SpriteColorTint tint = new SpriteColorTint(allUnits[i].gameObject);
+            tint.Apply(OrcBuffTintColor);
+            _orcTintedUnits.Add(tint);
+        }
+
+        if (orcSynergyLog)
+            DebugTool.Log(
+                $"오크 버프 적용 | percent={attackPercent:F1}%, tintedUnits={_orcTintedUnits.Count}",
+                DebugType.Synergy, this);
+    }
+
+    private void RemoveOrcBuff()
+    {
+        _isOrcBuffActive = false;
+        _orcBuffPercent = 0f;
+
+        for (int i = 0; i < _orcTintedUnits.Count; i++)
+        {
+            _orcTintedUnits[i]?.Remove();
+        }
+
+        _orcTintedUnits.Clear();
+
+        if (orcSynergyLog)
+            DebugTool.Log("오크 버프 해제 | 틴트 제거 완료", DebugType.Synergy, this);
+    }
+
+    private int GetOrcMinActiveCount()
+    {
+        if (synergySO == null)
+            return int.MaxValue;
+
+        const int orcId = (int)SynergyManager.SynergyType.Orc;
+        SynergyData orcData = GetSynergyData(orcId);
+
+        if (orcData == null || orcData.Levels == null || orcData.Levels.Count == 0)
+            return int.MaxValue;
+
+        return orcData.Levels[0].ActiveCount;
     }
 }

--- a/Bismuth/Assets/Scripts/이수형/Combat/DamageCalculator.cs
+++ b/Bismuth/Assets/Scripts/이수형/Combat/DamageCalculator.cs
@@ -7,6 +7,7 @@ public class DamageCalculator : MonoBehaviour
     private const int ArcherSynergyId = (int)SynergyManager.SynergyType.Archer;
     private const int FighterSynergyId = (int)SynergyManager.SynergyType.Fighter;
     private const int ElfSynergyId = (int)SynergyManager.SynergyType.Elf;
+    private const int OrcSynergyId = (int)SynergyManager.SynergyType.Orc;
 
     [Header("Synergy")]
     [SerializeField] private SynergySO synergySO;
@@ -28,9 +29,10 @@ public class DamageCalculator : MonoBehaviour
 
     public int CalculateNormalDamage(UnitStat attackerStat, float damageDealt, float defense, float crit)
     {
-        float warriorMultiplier = 1 + GetWarriorAttackMultiplier(attackerStat) * 0.01f;
-        float elfMultiplier = 1 + GetElfAttackMultiplier(attackerStat) * 0.01f;
-        float calculatedDamage = damageDealt * warriorMultiplier * elfMultiplier * (1f + crit) * (100f / (defense + 100f));
+        float warriorMultiplier = GetWarriorAttackMultiplier(attackerStat) * 0.01f;
+        float elfMultiplier = GetElfAttackMultiplier(attackerStat) * 0.01f;
+        float orcMultiplier = GetOrcAttackMultiplier(attackerStat) * 0.01f;
+        float calculatedDamage = damageDealt * (warriorMultiplier + elfMultiplier + orcMultiplier + 1f) * (1f + crit) * (100f / (defense + 100f));
 
         if (Random.value < calculatedDamage - (int)calculatedDamage)
             return (int)calculatedDamage + 1;
@@ -262,6 +264,28 @@ public class DamageCalculator : MonoBehaviour
         }
 
         return totalBonus;
+    }
+
+    private float GetOrcAttackMultiplier(UnitStat attackerStat)
+    {
+        if (!HasSynergyTag(attackerStat, OrcSynergyId))
+            return 0f;
+
+        if (CombatManager.Instance == null || !CombatManager.Instance.IsOrcBuffActive)
+            return 0f;
+
+        float bonus = CombatManager.Instance.OrcBuffPercent;
+
+        if (synergyLog && bonus > 0f)
+        {
+            DebugTool.Log(
+                $"오크 공격력 배율 적용 | unit={attackerStat.Name}, bonus={bonus:F2}",
+                DebugType.Synergy,
+                this
+            );
+        }
+
+        return bonus;
     }
 
     private void TryResolveSynergyManager()

--- a/Bismuth/Assets/Scripts/이수형/Monster/SpriteColorTint.cs
+++ b/Bismuth/Assets/Scripts/이수형/Monster/SpriteColorTint.cs
@@ -1,0 +1,73 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+
+public class SpriteColorTint
+{
+    private readonly SpriteRenderer[] _renderers;
+    private readonly Dictionary<SpriteRenderer, Color> _originalColors = new();
+    private readonly string _ownerName;
+    private bool _isTinted;
+
+    public bool IsTinted => _isTinted;
+
+
+    public SpriteColorTint(GameObject target)
+    {
+        if (target == null)
+        {
+            _renderers = System.Array.Empty<SpriteRenderer>();
+            _ownerName = "None";
+            DebugTool.Warnning("SpriteColorTint 초기화 실패 : target이 null입니다.", DebugType.Unit);
+            return;
+        }
+
+        _ownerName = target.name;
+        _renderers = target.GetComponentsInChildren<SpriteRenderer>(true);
+
+        DebugTool.Log(
+            $"SpriteColorTint 초기화 | owner={_ownerName}, rendererCount={_renderers.Length}",
+            DebugType.Unit);
+    }
+
+
+    public void Apply(Color tintColor)
+    {
+        _originalColors.Clear();
+
+        for (int i = 0; i < _renderers.Length; i++)
+        {
+            if (_renderers[i] == null)
+                continue;
+
+            _originalColors[_renderers[i]] = _renderers[i].color;
+            _renderers[i].color *= tintColor;
+        }
+
+        _isTinted = true;
+
+        DebugTool.Log(
+            $"틴트 적용 | owner={_ownerName}, color={tintColor}",
+            DebugType.Unit);
+    }
+
+
+    public void Remove()
+    {
+        for (int i = 0; i < _renderers.Length; i++)
+        {
+            if (_renderers[i] == null)
+                continue;
+
+            if (_originalColors.TryGetValue(_renderers[i], out Color original))
+                _renderers[i].color = original;
+        }
+
+        _originalColors.Clear();
+        _isTinted = false;
+
+        DebugTool.Log(
+            $"틴트 해제 | owner={_ownerName}",
+            DebugType.Unit);
+    }
+}

--- a/Bismuth/Assets/Scripts/이수형/Monster/SpriteColorTint.cs
+++ b/Bismuth/Assets/Scripts/이수형/Monster/SpriteColorTint.cs
@@ -1,0 +1,84 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// 특정 GameObject 하위의 모든 SpriteRenderer에 색상 틴트를 적용/해제하는 유틸 클래스.
+/// 틴트 적용 시 원본 색상을 저장하고 틴트 색상을 곱하며, 해제 시 원본으로 복원한다.
+/// </summary>
+public class SpriteColorTint
+{
+    private readonly SpriteRenderer[] _renderers;
+    private readonly Dictionary<SpriteRenderer, Color> _originalColors = new();
+    private readonly string _ownerName;
+    private bool _isTinted;
+
+    public bool IsTinted => _isTinted;
+
+    /// <summary>
+    /// 대상 오브젝트 하위의 모든 SpriteRenderer를 수집하여 초기화한다.
+    /// </summary>
+    /// <param name="target">틴트를 적용할 루트 오브젝트</param>
+    public SpriteColorTint(GameObject target)
+    {
+        if (target == null)
+        {
+            _renderers = System.Array.Empty<SpriteRenderer>();
+            _ownerName = "None";
+            DebugTool.Warnning("SpriteColorTint 초기화 실패 : target이 null입니다.", DebugType.Unit);
+            return;
+        }
+
+        _ownerName = target.name;
+        _renderers = target.GetComponentsInChildren<SpriteRenderer>(true);
+
+        DebugTool.Log(
+            $"SpriteColorTint 초기화 | owner={_ownerName}, rendererCount={_renderers.Length}",
+            DebugType.Unit);
+    }
+
+    /// <summary>
+    /// 틴트 색상을 적용한다. 원본 색상을 저장한 뒤 틴트를 곱한다.
+    /// </summary>
+    /// <param name="tintColor">적용할 틴트 색상</param>
+    public void Apply(Color tintColor)
+    {
+        _originalColors.Clear();
+
+        for (int i = 0; i < _renderers.Length; i++)
+        {
+            if (_renderers[i] == null)
+                continue;
+
+            _originalColors[_renderers[i]] = _renderers[i].color;
+            _renderers[i].color *= tintColor;
+        }
+
+        _isTinted = true;
+
+        DebugTool.Log(
+            $"틴트 적용 | owner={_ownerName}, color={tintColor}",
+            DebugType.Unit);
+    }
+
+    /// <summary>
+    /// 틴트를 해제하고 저장해둔 원본 색상으로 복원한다.
+    /// </summary>
+    public void Remove()
+    {
+        for (int i = 0; i < _renderers.Length; i++)
+        {
+            if (_renderers[i] == null)
+                continue;
+
+            if (_originalColors.TryGetValue(_renderers[i], out Color original))
+                _renderers[i].color = original;
+        }
+
+        _originalColors.Clear();
+        _isTinted = false;
+
+        DebugTool.Log(
+            $"틴트 해제 | owner={_ownerName}",
+            DebugType.Unit);
+    }
+}

--- a/Bismuth/Assets/Scripts/이수형/Monster/SpriteColorTint.cs.meta
+++ b/Bismuth/Assets/Scripts/이수형/Monster/SpriteColorTint.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 616a3fb8f2856fc4fb53f0c4a8fee6fa


### PR DESCRIPTION
- 정령 시너지(적 슬로우) 발동 시 적들에게 파란 필터를 씌우게 구현
- 오크 시너지 발동 시 오크유닛들에게 빨간 필터를 씌우게 구현

+ 미구현이었던 오크 시너지 구현했습니다.

