### PR TITLE
[Develop] 에서 [Bismuth]로 병합의 건

### DIFF
--- a/Bismuth/Assets/Data/Monsters/Monster_40101.asset
+++ b/Bismuth/Assets/Data/Monsters/Monster_40101.asset
@@ -16,9 +16,9 @@ MonoBehaviour:
   _displayName: "\uD574\uACE8 \uAE30\uC0AC"
   _category: 0
   _prefab: {fileID: 2545415603456560379, guid: d977911fe1518fd499008b0a608221b8, type: 3}
-  _baseHp: 65
-  _hpGrowth: 6.5
-  _baseDefense: 5
+  _baseHp: 68
+  _hpGrowth: 28
+  _baseDefense: 6
   _defenseGrowth: 0.6
   _moveSpeed: 1.3
   _waitTime: 0

--- a/Bismuth/Assets/Data/Monsters/Monster_40102.asset
+++ b/Bismuth/Assets/Data/Monsters/Monster_40102.asset
@@ -16,8 +16,8 @@ MonoBehaviour:
   _displayName: "\uC2AC\uB77C\uC784"
   _category: 0
   _prefab: {fileID: 3513261426189889022, guid: 05aaf7f1c7955704e9f9f32db099591b, type: 3}
-  _baseHp: 50
-  _hpGrowth: 6.5
+  _baseHp: 53
+  _hpGrowth: 28
   _baseDefense: 3
   _defenseGrowth: 0.5
   _moveSpeed: 3

--- a/Bismuth/Assets/Data/Monsters/Monster_40103.asset
+++ b/Bismuth/Assets/Data/Monsters/Monster_40103.asset
@@ -16,8 +16,8 @@ MonoBehaviour:
   _displayName: "\uBBF8\uBBF9"
   _category: 0
   _prefab: {fileID: 536209541323469559, guid: de49d6f3a3742034c819d64206162e84, type: 3}
-  _baseHp: 55
-  _hpGrowth: 6.5
+  _baseHp: 58
+  _hpGrowth: 28
   _baseDefense: 4
   _defenseGrowth: 1
   _moveSpeed: 2.5

--- a/Bismuth/Assets/Data/Monsters/Monster_40104.asset
+++ b/Bismuth/Assets/Data/Monsters/Monster_40104.asset
@@ -16,8 +16,8 @@ MonoBehaviour:
   _displayName: "\uC0C8\uB07C \uBC14\uB2E4\uBC40"
   _category: 0
   _prefab: {fileID: 8518705353674516049, guid: d70d95bea44d48b459a2b984a1cab391, type: 3}
-  _baseHp: 55
-  _hpGrowth: 6.5
+  _baseHp: 68
+  _hpGrowth: 28
   _baseDefense: 6
   _defenseGrowth: 0.6
   _moveSpeed: 1.2

--- a/Bismuth/Assets/Data/Monsters/Monster_40105.asset
+++ b/Bismuth/Assets/Data/Monsters/Monster_40105.asset
@@ -16,8 +16,8 @@ MonoBehaviour:
   _displayName: "\uC0C8\uB07C \uD06C\uD234\uB8E8"
   _category: 0
   _prefab: {fileID: 4120820958544433772, guid: 20177697751b3d846828d187cde59376, type: 3}
-  _baseHp: 40
-  _hpGrowth: 6.5
+  _baseHp: 58
+  _hpGrowth: 28
   _baseDefense: 5
   _defenseGrowth: 1
   _moveSpeed: 2.5

--- a/Bismuth/Assets/Data/Monsters/Monster_40106.asset
+++ b/Bismuth/Assets/Data/Monsters/Monster_40106.asset
@@ -16,8 +16,8 @@ MonoBehaviour:
   _displayName: "\uB808\uADF8 \uD53C\uC26C"
   _category: 0
   _prefab: {fileID: 1564217701671441200, guid: a11a3c15bfb966246ac28696e24b9eb4, type: 3}
-  _baseHp: 45
-  _hpGrowth: 6.5
+  _baseHp: 53
+  _hpGrowth: 28
   _baseDefense: 4
   _defenseGrowth: 0.5
   _moveSpeed: 3

--- a/Bismuth/Assets/Data/Monsters/Monster_40107.asset
+++ b/Bismuth/Assets/Data/Monsters/Monster_40107.asset
@@ -16,9 +16,9 @@ MonoBehaviour:
   _displayName: "\uACE0\uC2A4\uD2B8"
   _category: 0
   _prefab: {fileID: 2568165291497397196, guid: f66b558cbfdf5ee4a9665cedcf6aa91b, type: 3}
-  _baseHp: 65
-  _hpGrowth: 6.5
-  _baseDefense: 5
+  _baseHp: 68
+  _hpGrowth: 28
+  _baseDefense: 6
   _defenseGrowth: 0.6
   _moveSpeed: 1.3
   _waitTime: 0

--- a/Bismuth/Assets/Data/Monsters/Monster_40108.asset
+++ b/Bismuth/Assets/Data/Monsters/Monster_40108.asset
@@ -16,8 +16,8 @@ MonoBehaviour:
   _displayName: "\uC218\uD638\uC790 \uACE0\uC2A4\uD2B8"
   _category: 0
   _prefab: {fileID: 4398334563330642494, guid: 5bebaa485b9127a4a8f510ec77da60c5, type: 3}
-  _baseHp: 55
-  _hpGrowth: 6.5
+  _baseHp: 58
+  _hpGrowth: 28
   _baseDefense: 4
   _defenseGrowth: 1
   _moveSpeed: 2.5

--- a/Bismuth/Assets/Data/Monsters/Monster_40109.asset
+++ b/Bismuth/Assets/Data/Monsters/Monster_40109.asset
@@ -16,8 +16,8 @@ MonoBehaviour:
   _displayName: "\uAC00\uACE0\uC77C \uBCD1\uC815"
   _category: 0
   _prefab: {fileID: 9218577407584293264, guid: 7b50a6220842fb44cb7093eb7701bfaa, type: 3}
-  _baseHp: 50
-  _hpGrowth: 6.5
+  _baseHp: 53
+  _hpGrowth: 28
   _baseDefense: 3
   _defenseGrowth: 0.5
   _moveSpeed: 3

--- a/Bismuth/Assets/Data/Monsters/Monster_40201.asset
+++ b/Bismuth/Assets/Data/Monsters/Monster_40201.asset
@@ -16,7 +16,7 @@ MonoBehaviour:
   _displayName: "\uD574\uACE8 \uC655"
   _category: 1
   _prefab: {fileID: 4155783173439602419, guid: 754b9bb416f71354aa2ec851f4c74ecf, type: 3}
-  _baseHp: 1300
+  _baseHp: 1250
   _hpGrowth: 1
   _baseDefense: 25
   _defenseGrowth: 0

--- a/Bismuth/Assets/Data/Monsters/Monster_40202.asset
+++ b/Bismuth/Assets/Data/Monsters/Monster_40202.asset
@@ -16,7 +16,7 @@ MonoBehaviour:
   _displayName: "\uD0B9 \uC2AC\uB77C\uC784"
   _category: 1
   _prefab: {fileID: 5680661409375122043, guid: dc43f4898852136499c94ee0f4851338, type: 3}
-  _baseHp: 2000
+  _baseHp: 2100
   _hpGrowth: 3.5
   _baseDefense: 10
   _defenseGrowth: 0.7

--- a/Bismuth/Assets/Data/Monsters/Monster_40203.asset
+++ b/Bismuth/Assets/Data/Monsters/Monster_40203.asset
@@ -16,7 +16,7 @@ MonoBehaviour:
   _displayName: "\uD76C\uC0DD\uC790\uC758 \uC6D0\uB150"
   _category: 1
   _prefab: {fileID: 1970477506321799213, guid: 18e0349e71604b942afc777df0a9bf4e, type: 3}
-  _baseHp: 3100
+  _baseHp: 2400
   _hpGrowth: 2
   _baseDefense: 10
   _defenseGrowth: 0.8

--- a/Bismuth/Assets/Data/Monsters/Monster_40204.asset
+++ b/Bismuth/Assets/Data/Monsters/Monster_40204.asset
@@ -16,7 +16,7 @@ MonoBehaviour:
   _displayName: "\uBC14\uB2E4\uBC40"
   _category: 1
   _prefab: {fileID: 3160355594879278532, guid: c729cbc4415fd374da72b1236cb8484f, type: 3}
-  _baseHp: 1100
+  _baseHp: 1250
   _hpGrowth: 1
   _baseDefense: 25
   _defenseGrowth: 0

--- a/Bismuth/Assets/Data/Monsters/Monster_40205.asset
+++ b/Bismuth/Assets/Data/Monsters/Monster_40205.asset
@@ -16,7 +16,7 @@ MonoBehaviour:
   _displayName: "\uC120\uC7A5 \uD06C\uD234\uB8E8"
   _category: 1
   _prefab: {fileID: 5827097886258357182, guid: e972f5b40cf1ba1438aa5e934e137824, type: 3}
-  _baseHp: 3000
+  _baseHp: 2400
   _hpGrowth: 2
   _baseDefense: 10
   _defenseGrowth: 0.8

--- a/Bismuth/Assets/Data/Monsters/Monster_40206.asset
+++ b/Bismuth/Assets/Data/Monsters/Monster_40206.asset
@@ -16,7 +16,7 @@ MonoBehaviour:
   _displayName: "\uD038 \uB808\uADF8\uD53C\uC26C"
   _category: 1
   _prefab: {fileID: 7866877623990814809, guid: 19a140dfca1c98645bcd121be77aa43b, type: 3}
-  _baseHp: 2000
+  _baseHp: 2100
   _hpGrowth: 3.5
   _baseDefense: 10
   _defenseGrowth: 0.7

--- a/Bismuth/Assets/Data/Monsters/Monster_40207.asset
+++ b/Bismuth/Assets/Data/Monsters/Monster_40207.asset
@@ -16,7 +16,7 @@ MonoBehaviour:
   _displayName: "\uC720\uC801 \uC218\uD638\uC790"
   _category: 1
   _prefab: {fileID: 8433081711580898326, guid: 8b123fd3369dd9f458bb51166140a80a, type: 3}
-  _baseHp: 1200
+  _baseHp: 1250
   _hpGrowth: 1
   _baseDefense: 25
   _defenseGrowth: 0

--- a/Bismuth/Assets/Data/Monsters/Monster_40208.asset
+++ b/Bismuth/Assets/Data/Monsters/Monster_40208.asset
@@ -16,7 +16,7 @@ MonoBehaviour:
   _displayName: "\uC720\uC801 \uC2EC\uD310\uC790"
   _category: 1
   _prefab: {fileID: 3895921769988453133, guid: f8b4e79129226f449adad886fc375e1e, type: 3}
-  _baseHp: 3100
+  _baseHp: 2400
   _hpGrowth: 2
   _baseDefense: 10
   _defenseGrowth: 0.8

--- a/Bismuth/Assets/Data/Monsters/Monster_40209.asset
+++ b/Bismuth/Assets/Data/Monsters/Monster_40209.asset
@@ -16,7 +16,7 @@ MonoBehaviour:
   _displayName: "\uAC00\uACE0\uC77C \uB300\uC7A5"
   _category: 1
   _prefab: {fileID: 5587212859042961002, guid: cc0e3bee069242b4d82e0944ef5168ec, type: 3}
-  _baseHp: 2000
+  _baseHp: 2100
   _hpGrowth: 3.5
   _baseDefense: 10
   _defenseGrowth: 0.7

--- a/Bismuth/Assets/Data/Waves/Difficulty/DifficultyModifierTableSO.asset
+++ b/Bismuth/Assets/Data/Waves/Difficulty/DifficultyModifierTableSO.asset
@@ -30,4 +30,4 @@ MonoBehaviour:
     _resourceGainMultiplier: 0.8
     _enemyToBaseDamageMultiplier: 1
     _enemyHpMultiplier: 1.1
-    _teamBaseHpMultiplier: 0.8
+    _teamBaseHpMultiplier: 0.1

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90500_11.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90500_11.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 11
   _difficultyModifierId: 90500
-  _clearReward: 90
+  _clearReward: 70
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: a72868a7f0622b9408ee669f7be1a3bd, type: 2}
     _count: 10

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90500_12.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90500_12.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 12
   _difficultyModifierId: 90500
-  _clearReward: 90
+  _clearReward: 70
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: a72868a7f0622b9408ee669f7be1a3bd, type: 2}
     _count: 12

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90500_13.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90500_13.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 13
   _difficultyModifierId: 90500
-  _clearReward: 90
+  _clearReward: 70
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: a72868a7f0622b9408ee669f7be1a3bd, type: 2}
     _count: 14

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90500_14.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90500_14.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 14
   _difficultyModifierId: 90500
-  _clearReward: 90
+  _clearReward: 70
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: a72868a7f0622b9408ee669f7be1a3bd, type: 2}
     _count: 16

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90500_15.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90500_15.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 15
   _difficultyModifierId: 90500
-  _clearReward: 90
+  _clearReward: 70
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: a72868a7f0622b9408ee669f7be1a3bd, type: 2}
     _count: 18

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90500_16.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90500_16.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 16
   _difficultyModifierId: 90500
-  _clearReward: 90
+  _clearReward: 70
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: a72868a7f0622b9408ee669f7be1a3bd, type: 2}
     _count: 20

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90500_17.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90500_17.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 17
   _difficultyModifierId: 90500
-  _clearReward: 88
+  _clearReward: 68
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: a72868a7f0622b9408ee669f7be1a3bd, type: 2}
     _count: 24

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90500_18.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90500_18.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 18
   _difficultyModifierId: 90500
-  _clearReward: 88
+  _clearReward: 68
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: a72868a7f0622b9408ee669f7be1a3bd, type: 2}
     _count: 26

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90500_19.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90500_19.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 19
   _difficultyModifierId: 90500
-  _clearReward: 86
+  _clearReward: 66
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: a72868a7f0622b9408ee669f7be1a3bd, type: 2}
     _count: 30

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90500_21.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90500_21.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 21
   _difficultyModifierId: 90500
-  _clearReward: 130
+  _clearReward: 90
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 8f87d2aae1dea58408201fc2e39f7eba, type: 2}
     _count: 20

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90500_22.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90500_22.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 22
   _difficultyModifierId: 90500
-  _clearReward: 130
+  _clearReward: 90
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 8f87d2aae1dea58408201fc2e39f7eba, type: 2}
     _count: 22

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90500_23.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90500_23.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 23
   _difficultyModifierId: 90500
-  _clearReward: 130
+  _clearReward: 90
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 8f87d2aae1dea58408201fc2e39f7eba, type: 2}
     _count: 24

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90500_24.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90500_24.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 24
   _difficultyModifierId: 90500
-  _clearReward: 130
+  _clearReward: 90
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 8f87d2aae1dea58408201fc2e39f7eba, type: 2}
     _count: 26

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90500_25.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90500_25.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 25
   _difficultyModifierId: 90500
-  _clearReward: 130
+  _clearReward: 90
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 8f87d2aae1dea58408201fc2e39f7eba, type: 2}
     _count: 28

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90500_26.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90500_26.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 26
   _difficultyModifierId: 90500
-  _clearReward: 130
+  _clearReward: 90
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 8f87d2aae1dea58408201fc2e39f7eba, type: 2}
     _count: 30

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90500_27.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90500_27.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 27
   _difficultyModifierId: 90500
-  _clearReward: 128
+  _clearReward: 88
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 8f87d2aae1dea58408201fc2e39f7eba, type: 2}
     _count: 34

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90500_28.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90500_28.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 28
   _difficultyModifierId: 90500
-  _clearReward: 128
+  _clearReward: 88
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 8f87d2aae1dea58408201fc2e39f7eba, type: 2}
     _count: 36

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90500_29.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90500_29.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 29
   _difficultyModifierId: 90500
-  _clearReward: 126
+  _clearReward: 86
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 8f87d2aae1dea58408201fc2e39f7eba, type: 2}
     _count: 40

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90501_11.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90501_11.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 11
   _difficultyModifierId: 90501
-  _clearReward: 90
+  _clearReward: 70
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: a72868a7f0622b9408ee669f7be1a3bd, type: 2}
     _count: 10

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90501_12.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90501_12.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 12
   _difficultyModifierId: 90501
-  _clearReward: 90
+  _clearReward: 70
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: a72868a7f0622b9408ee669f7be1a3bd, type: 2}
     _count: 12

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90501_13.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90501_13.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 13
   _difficultyModifierId: 90501
-  _clearReward: 90
+  _clearReward: 70
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: a72868a7f0622b9408ee669f7be1a3bd, type: 2}
     _count: 14

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90501_14.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90501_14.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 14
   _difficultyModifierId: 90501
-  _clearReward: 90
+  _clearReward: 70
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: a72868a7f0622b9408ee669f7be1a3bd, type: 2}
     _count: 16

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90501_15.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90501_15.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 15
   _difficultyModifierId: 90501
-  _clearReward: 90
+  _clearReward: 70
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: a72868a7f0622b9408ee669f7be1a3bd, type: 2}
     _count: 18

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90501_16.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90501_16.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 16
   _difficultyModifierId: 90501
-  _clearReward: 90
+  _clearReward: 70
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: a72868a7f0622b9408ee669f7be1a3bd, type: 2}
     _count: 20

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90501_17.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90501_17.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 17
   _difficultyModifierId: 90501
-  _clearReward: 88
+  _clearReward: 68
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: a72868a7f0622b9408ee669f7be1a3bd, type: 2}
     _count: 24

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90501_18.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90501_18.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 18
   _difficultyModifierId: 90501
-  _clearReward: 88
+  _clearReward: 68
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: a72868a7f0622b9408ee669f7be1a3bd, type: 2}
     _count: 26

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90501_19.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90501_19.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 19
   _difficultyModifierId: 90501
-  _clearReward: 86
+  _clearReward: 66
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: a72868a7f0622b9408ee669f7be1a3bd, type: 2}
     _count: 30

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90501_21.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90501_21.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 21
   _difficultyModifierId: 90501
-  _clearReward: 130
+  _clearReward: 90
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 8f87d2aae1dea58408201fc2e39f7eba, type: 2}
     _count: 20

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90501_22.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90501_22.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 22
   _difficultyModifierId: 90501
-  _clearReward: 130
+  _clearReward: 90
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 8f87d2aae1dea58408201fc2e39f7eba, type: 2}
     _count: 22

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90501_23.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90501_23.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 23
   _difficultyModifierId: 90501
-  _clearReward: 130
+  _clearReward: 90
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 8f87d2aae1dea58408201fc2e39f7eba, type: 2}
     _count: 24

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90501_24.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90501_24.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 24
   _difficultyModifierId: 90501
-  _clearReward: 130
+  _clearReward: 90
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 8f87d2aae1dea58408201fc2e39f7eba, type: 2}
     _count: 26

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90501_25.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90501_25.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 25
   _difficultyModifierId: 90501
-  _clearReward: 130
+  _clearReward: 90
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 8f87d2aae1dea58408201fc2e39f7eba, type: 2}
     _count: 28

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90501_26.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90501_26.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 26
   _difficultyModifierId: 90501
-  _clearReward: 130
+  _clearReward: 90
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 8f87d2aae1dea58408201fc2e39f7eba, type: 2}
     _count: 30

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90501_27.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90501_27.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 27
   _difficultyModifierId: 90501
-  _clearReward: 128
+  _clearReward: 88
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 8f87d2aae1dea58408201fc2e39f7eba, type: 2}
     _count: 34

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90501_28.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90501_28.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 28
   _difficultyModifierId: 90501
-  _clearReward: 128
+  _clearReward: 88
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 8f87d2aae1dea58408201fc2e39f7eba, type: 2}
     _count: 36

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90501_29.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90501_29.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 29
   _difficultyModifierId: 90501
-  _clearReward: 126
+  _clearReward: 86
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 8f87d2aae1dea58408201fc2e39f7eba, type: 2}
     _count: 40

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90501_31.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90501_31.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 31
   _difficultyModifierId: 90501
-  _clearReward: 160
+  _clearReward: 130
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 5fbb1682dd13b724c97fcf58645aa081, type: 2}
     _count: 25

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90501_32.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90501_32.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 32
   _difficultyModifierId: 90501
-  _clearReward: 157
+  _clearReward: 127
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 5fbb1682dd13b724c97fcf58645aa081, type: 2}
     _count: 30

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90501_33.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90501_33.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 33
   _difficultyModifierId: 90501
-  _clearReward: 154
+  _clearReward: 124
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 5fbb1682dd13b724c97fcf58645aa081, type: 2}
     _count: 30

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90501_34.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90501_34.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 34
   _difficultyModifierId: 90501
-  _clearReward: 166
+  _clearReward: 136
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 5fbb1682dd13b724c97fcf58645aa081, type: 2}
     _count: 25

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90501_35.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90501_35.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 35
   _difficultyModifierId: 90501
-  _clearReward: 163
+  _clearReward: 133
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 5fbb1682dd13b724c97fcf58645aa081, type: 2}
     _count: 30

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90501_36.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90501_36.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 36
   _difficultyModifierId: 90501
-  _clearReward: 160
+  _clearReward: 130
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 5fbb1682dd13b724c97fcf58645aa081, type: 2}
     _count: 30

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90501_37.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90501_37.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 37
   _difficultyModifierId: 90501
-  _clearReward: 172
+  _clearReward: 142
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: a72868a7f0622b9408ee669f7be1a3bd, type: 2}
     _count: 25

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90501_38.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90501_38.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 38
   _difficultyModifierId: 90501
-  _clearReward: 169
+  _clearReward: 139
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: a72868a7f0622b9408ee669f7be1a3bd, type: 2}
     _count: 30

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90501_39.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90501_39.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 39
   _difficultyModifierId: 90501
-  _clearReward: 166
+  _clearReward: 136
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: a72868a7f0622b9408ee669f7be1a3bd, type: 2}
     _count: 30

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90501_41.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90501_41.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 41
   _difficultyModifierId: 90501
-  _clearReward: 200
+  _clearReward: 160
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 5fbb1682dd13b724c97fcf58645aa081, type: 2}
     _count: 20

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90501_42.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90501_42.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 42
   _difficultyModifierId: 90501
-  _clearReward: 192
+  _clearReward: 152
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 5fbb1682dd13b724c97fcf58645aa081, type: 2}
     _count: 25

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90501_43.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90501_43.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 43
   _difficultyModifierId: 90501
-  _clearReward: 184
+  _clearReward: 144
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 5fbb1682dd13b724c97fcf58645aa081, type: 2}
     _count: 30

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90501_44.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90501_44.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 44
   _difficultyModifierId: 90501
-  _clearReward: 176
+  _clearReward: 136
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 5fbb1682dd13b724c97fcf58645aa081, type: 2}
     _count: 35

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90501_45.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90501_45.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 45
   _difficultyModifierId: 90501
-  _clearReward: 168
+  _clearReward: 128
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 5fbb1682dd13b724c97fcf58645aa081, type: 2}
     _count: 40

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90501_46.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90501_46.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 46
   _difficultyModifierId: 90501
-  _clearReward: 160
+  _clearReward: 120
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 5fbb1682dd13b724c97fcf58645aa081, type: 2}
     _count: 45

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90501_47.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90501_47.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 47
   _difficultyModifierId: 90501
-  _clearReward: 152
+  _clearReward: 112
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 5fbb1682dd13b724c97fcf58645aa081, type: 2}
     _count: 50

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90501_48.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90501_48.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 48
   _difficultyModifierId: 90501
-  _clearReward: 144
+  _clearReward: 104
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 5fbb1682dd13b724c97fcf58645aa081, type: 2}
     _count: 55

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90501_49.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90501_49.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 49
   _difficultyModifierId: 90501
-  _clearReward: 136
+  _clearReward: 96
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 5fbb1682dd13b724c97fcf58645aa081, type: 2}
     _count: 60

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90502_11.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90502_11.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 11
   _difficultyModifierId: 90502
-  _clearReward: 72
+  _clearReward: 56
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: a72868a7f0622b9408ee669f7be1a3bd, type: 2}
     _count: 20

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90502_12.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90502_12.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 12
   _difficultyModifierId: 90502
-  _clearReward: 72
+  _clearReward: 56
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: a72868a7f0622b9408ee669f7be1a3bd, type: 2}
     _count: 24

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90502_13.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90502_13.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 13
   _difficultyModifierId: 90502
-  _clearReward: 72
+  _clearReward: 56
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: a72868a7f0622b9408ee669f7be1a3bd, type: 2}
     _count: 28

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90502_14.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90502_14.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 14
   _difficultyModifierId: 90502
-  _clearReward: 72
+  _clearReward: 56
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: a72868a7f0622b9408ee669f7be1a3bd, type: 2}
     _count: 32

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90502_15.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90502_15.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 15
   _difficultyModifierId: 90502
-  _clearReward: 72
+  _clearReward: 56
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: a72868a7f0622b9408ee669f7be1a3bd, type: 2}
     _count: 36

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90502_16.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90502_16.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 16
   _difficultyModifierId: 90502
-  _clearReward: 72
+  _clearReward: 56
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: a72868a7f0622b9408ee669f7be1a3bd, type: 2}
     _count: 40

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90502_17.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90502_17.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 17
   _difficultyModifierId: 90502
-  _clearReward: 70
+  _clearReward: 54
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: a72868a7f0622b9408ee669f7be1a3bd, type: 2}
     _count: 48

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90502_18.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90502_18.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 18
   _difficultyModifierId: 90502
-  _clearReward: 70
+  _clearReward: 54
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: a72868a7f0622b9408ee669f7be1a3bd, type: 2}
     _count: 52

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90502_19.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90502_19.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 19
   _difficultyModifierId: 90502
-  _clearReward: 69
+  _clearReward: 53
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: a72868a7f0622b9408ee669f7be1a3bd, type: 2}
     _count: 60

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90502_21.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90502_21.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 21
   _difficultyModifierId: 90502
-  _clearReward: 104
+  _clearReward: 72
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 8f87d2aae1dea58408201fc2e39f7eba, type: 2}
     _count: 40

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90502_22.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90502_22.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 22
   _difficultyModifierId: 90502
-  _clearReward: 104
+  _clearReward: 72
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 8f87d2aae1dea58408201fc2e39f7eba, type: 2}
     _count: 44

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90502_23.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90502_23.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 23
   _difficultyModifierId: 90502
-  _clearReward: 104
+  _clearReward: 72
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 8f87d2aae1dea58408201fc2e39f7eba, type: 2}
     _count: 48

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90502_24.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90502_24.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 24
   _difficultyModifierId: 90502
-  _clearReward: 104
+  _clearReward: 72
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 8f87d2aae1dea58408201fc2e39f7eba, type: 2}
     _count: 52

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90502_25.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90502_25.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 25
   _difficultyModifierId: 90502
-  _clearReward: 104
+  _clearReward: 72
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 8f87d2aae1dea58408201fc2e39f7eba, type: 2}
     _count: 56

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90502_26.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90502_26.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 26
   _difficultyModifierId: 90502
-  _clearReward: 104
+  _clearReward: 72
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 8f87d2aae1dea58408201fc2e39f7eba, type: 2}
     _count: 60

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90502_27.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90502_27.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 27
   _difficultyModifierId: 90502
-  _clearReward: 102
+  _clearReward: 70
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 8f87d2aae1dea58408201fc2e39f7eba, type: 2}
     _count: 68

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90502_28.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90502_28.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 28
   _difficultyModifierId: 90502
-  _clearReward: 102
+  _clearReward: 70
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 8f87d2aae1dea58408201fc2e39f7eba, type: 2}
     _count: 72

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90502_29.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90502_29.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 29
   _difficultyModifierId: 90502
-  _clearReward: 101
+  _clearReward: 69
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 8f87d2aae1dea58408201fc2e39f7eba, type: 2}
     _count: 40

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90502_31.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90502_31.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 31
   _difficultyModifierId: 90502
-  _clearReward: 128
+  _clearReward: 104
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 5fbb1682dd13b724c97fcf58645aa081, type: 2}
     _count: 50

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90502_32.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90502_32.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 32
   _difficultyModifierId: 90502
-  _clearReward: 126
+  _clearReward: 102
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 5fbb1682dd13b724c97fcf58645aa081, type: 2}
     _count: 60

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90502_33.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90502_33.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 33
   _difficultyModifierId: 90502
-  _clearReward: 123
+  _clearReward: 99
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 5fbb1682dd13b724c97fcf58645aa081, type: 2}
     _count: 60

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90502_34.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90502_34.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 34
   _difficultyModifierId: 90502
-  _clearReward: 133
+  _clearReward: 109
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 5fbb1682dd13b724c97fcf58645aa081, type: 2}
     _count: 50

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90502_35.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90502_35.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 35
   _difficultyModifierId: 90502
-  _clearReward: 130
+  _clearReward: 106
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 5fbb1682dd13b724c97fcf58645aa081, type: 2}
     _count: 60

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90502_36.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90502_36.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 36
   _difficultyModifierId: 90502
-  _clearReward: 128
+  _clearReward: 104
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 5fbb1682dd13b724c97fcf58645aa081, type: 2}
     _count: 60

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90502_37.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90502_37.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 37
   _difficultyModifierId: 90502
-  _clearReward: 138
+  _clearReward: 114
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: a72868a7f0622b9408ee669f7be1a3bd, type: 2}
     _count: 50

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90502_38.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90502_38.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 38
   _difficultyModifierId: 90502
-  _clearReward: 135
+  _clearReward: 111
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: a72868a7f0622b9408ee669f7be1a3bd, type: 2}
     _count: 60

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90502_39.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90502_39.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 39
   _difficultyModifierId: 90502
-  _clearReward: 133
+  _clearReward: 109
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: a72868a7f0622b9408ee669f7be1a3bd, type: 2}
     _count: 60

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90502_41.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90502_41.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 41
   _difficultyModifierId: 90502
-  _clearReward: 160
+  _clearReward: 128
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 5fbb1682dd13b724c97fcf58645aa081, type: 2}
     _count: 40

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90502_42.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90502_42.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 42
   _difficultyModifierId: 90502
-  _clearReward: 154
+  _clearReward: 122
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 5fbb1682dd13b724c97fcf58645aa081, type: 2}
     _count: 50

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90502_43.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90502_43.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 43
   _difficultyModifierId: 90502
-  _clearReward: 147
+  _clearReward: 115
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 5fbb1682dd13b724c97fcf58645aa081, type: 2}
     _count: 60

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90502_44.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90502_44.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 44
   _difficultyModifierId: 90502
-  _clearReward: 141
+  _clearReward: 109
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 5fbb1682dd13b724c97fcf58645aa081, type: 2}
     _count: 70

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90502_45.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90502_45.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 45
   _difficultyModifierId: 90502
-  _clearReward: 134
+  _clearReward: 102
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 5fbb1682dd13b724c97fcf58645aa081, type: 2}
     _count: 80

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90502_46.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90502_46.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 46
   _difficultyModifierId: 90502
-  _clearReward: 128
+  _clearReward: 96
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 5fbb1682dd13b724c97fcf58645aa081, type: 2}
     _count: 90

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90502_47.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90502_47.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 47
   _difficultyModifierId: 90502
-  _clearReward: 122
+  _clearReward: 90
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 5fbb1682dd13b724c97fcf58645aa081, type: 2}
     _count: 100

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90502_48.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90502_48.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 48
   _difficultyModifierId: 90502
-  _clearReward: 115
+  _clearReward: 83
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 5fbb1682dd13b724c97fcf58645aa081, type: 2}
     _count: 110

--- a/Bismuth/Assets/Data/Waves/Forest/Wave_90502_49.asset
+++ b/Bismuth/Assets/Data/Waves/Forest/Wave_90502_49.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 49
   _difficultyModifierId: 90502
-  _clearReward: 109
+  _clearReward: 77
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 5fbb1682dd13b724c97fcf58645aa081, type: 2}
     _count: 120

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90500_11.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90500_11.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 11
   _difficultyModifierId: 90500
-  _clearReward: 90
+  _clearReward: 70
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: f044c3a810846ba4e88d00386bfe7824, type: 2}
     _count: 10

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90500_12.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90500_12.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 12
   _difficultyModifierId: 90500
-  _clearReward: 90
+  _clearReward: 70
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: f044c3a810846ba4e88d00386bfe7824, type: 2}
     _count: 12

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90500_13.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90500_13.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 13
   _difficultyModifierId: 90500
-  _clearReward: 90
+  _clearReward: 70
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: f044c3a810846ba4e88d00386bfe7824, type: 2}
     _count: 14

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90500_14.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90500_14.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 14
   _difficultyModifierId: 90500
-  _clearReward: 90
+  _clearReward: 70
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: f044c3a810846ba4e88d00386bfe7824, type: 2}
     _count: 16

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90500_15.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90500_15.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 15
   _difficultyModifierId: 90500
-  _clearReward: 90
+  _clearReward: 70
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: f044c3a810846ba4e88d00386bfe7824, type: 2}
     _count: 18

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90500_16.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90500_16.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 16
   _difficultyModifierId: 90500
-  _clearReward: 90
+  _clearReward: 70
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: f044c3a810846ba4e88d00386bfe7824, type: 2}
     _count: 20

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90500_17.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90500_17.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 17
   _difficultyModifierId: 90500
-  _clearReward: 88
+  _clearReward: 68
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: f044c3a810846ba4e88d00386bfe7824, type: 2}
     _count: 24

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90500_18.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90500_18.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 18
   _difficultyModifierId: 90500
-  _clearReward: 88
+  _clearReward: 68
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: f044c3a810846ba4e88d00386bfe7824, type: 2}
     _count: 26

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90500_19.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90500_19.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 19
   _difficultyModifierId: 90500
-  _clearReward: 86
+  _clearReward: 66
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: f044c3a810846ba4e88d00386bfe7824, type: 2}
     _count: 30

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90500_21.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90500_21.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 21
   _difficultyModifierId: 90500
-  _clearReward: 130
+  _clearReward: 90
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: edd1db5e8e57ac147a054fff9e9f85a3, type: 2}
     _count: 20

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90500_22.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90500_22.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 22
   _difficultyModifierId: 90500
-  _clearReward: 130
+  _clearReward: 90
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: edd1db5e8e57ac147a054fff9e9f85a3, type: 2}
     _count: 22

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90500_23.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90500_23.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 23
   _difficultyModifierId: 90500
-  _clearReward: 130
+  _clearReward: 90
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: edd1db5e8e57ac147a054fff9e9f85a3, type: 2}
     _count: 24

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90500_24.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90500_24.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 24
   _difficultyModifierId: 90500
-  _clearReward: 130
+  _clearReward: 90
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: edd1db5e8e57ac147a054fff9e9f85a3, type: 2}
     _count: 26

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90500_25.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90500_25.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 25
   _difficultyModifierId: 90500
-  _clearReward: 130
+  _clearReward: 90
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: edd1db5e8e57ac147a054fff9e9f85a3, type: 2}
     _count: 28

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90500_26.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90500_26.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 26
   _difficultyModifierId: 90500
-  _clearReward: 130
+  _clearReward: 90
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: edd1db5e8e57ac147a054fff9e9f85a3, type: 2}
     _count: 30

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90500_27.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90500_27.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 27
   _difficultyModifierId: 90500
-  _clearReward: 128
+  _clearReward: 88
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: edd1db5e8e57ac147a054fff9e9f85a3, type: 2}
     _count: 34

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90500_28.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90500_28.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 28
   _difficultyModifierId: 90500
-  _clearReward: 128
+  _clearReward: 88
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: edd1db5e8e57ac147a054fff9e9f85a3, type: 2}
     _count: 36

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90500_29.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90500_29.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 29
   _difficultyModifierId: 90500
-  _clearReward: 126
+  _clearReward: 86
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: edd1db5e8e57ac147a054fff9e9f85a3, type: 2}
     _count: 40

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90501_11.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90501_11.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 11
   _difficultyModifierId: 90501
-  _clearReward: 90
+  _clearReward: 70
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: f044c3a810846ba4e88d00386bfe7824, type: 2}
     _count: 10

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90501_12.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90501_12.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 12
   _difficultyModifierId: 90501
-  _clearReward: 90
+  _clearReward: 70
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: f044c3a810846ba4e88d00386bfe7824, type: 2}
     _count: 12

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90501_13.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90501_13.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 13
   _difficultyModifierId: 90501
-  _clearReward: 90
+  _clearReward: 70
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: f044c3a810846ba4e88d00386bfe7824, type: 2}
     _count: 14

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90501_14.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90501_14.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 14
   _difficultyModifierId: 90501
-  _clearReward: 90
+  _clearReward: 70
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: f044c3a810846ba4e88d00386bfe7824, type: 2}
     _count: 16

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90501_15.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90501_15.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 15
   _difficultyModifierId: 90501
-  _clearReward: 90
+  _clearReward: 70
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: f044c3a810846ba4e88d00386bfe7824, type: 2}
     _count: 18

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90501_16.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90501_16.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 16
   _difficultyModifierId: 90501
-  _clearReward: 90
+  _clearReward: 70
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: f044c3a810846ba4e88d00386bfe7824, type: 2}
     _count: 20

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90501_17.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90501_17.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 17
   _difficultyModifierId: 90501
-  _clearReward: 88
+  _clearReward: 68
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: f044c3a810846ba4e88d00386bfe7824, type: 2}
     _count: 24

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90501_18.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90501_18.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 18
   _difficultyModifierId: 90501
-  _clearReward: 88
+  _clearReward: 68
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: f044c3a810846ba4e88d00386bfe7824, type: 2}
     _count: 26

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90501_19.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90501_19.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 19
   _difficultyModifierId: 90501
-  _clearReward: 86
+  _clearReward: 66
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: f044c3a810846ba4e88d00386bfe7824, type: 2}
     _count: 30

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90501_21.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90501_21.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 21
   _difficultyModifierId: 90501
-  _clearReward: 130
+  _clearReward: 90
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: edd1db5e8e57ac147a054fff9e9f85a3, type: 2}
     _count: 20

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90501_22.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90501_22.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 22
   _difficultyModifierId: 90501
-  _clearReward: 130
+  _clearReward: 90
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: edd1db5e8e57ac147a054fff9e9f85a3, type: 2}
     _count: 22

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90501_23.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90501_23.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 23
   _difficultyModifierId: 90501
-  _clearReward: 130
+  _clearReward: 90
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: edd1db5e8e57ac147a054fff9e9f85a3, type: 2}
     _count: 24

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90501_24.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90501_24.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 24
   _difficultyModifierId: 90501
-  _clearReward: 130
+  _clearReward: 90
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: edd1db5e8e57ac147a054fff9e9f85a3, type: 2}
     _count: 26

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90501_25.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90501_25.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 25
   _difficultyModifierId: 90501
-  _clearReward: 130
+  _clearReward: 90
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: edd1db5e8e57ac147a054fff9e9f85a3, type: 2}
     _count: 28

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90501_26.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90501_26.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 26
   _difficultyModifierId: 90501
-  _clearReward: 130
+  _clearReward: 90
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: edd1db5e8e57ac147a054fff9e9f85a3, type: 2}
     _count: 30

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90501_27.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90501_27.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 27
   _difficultyModifierId: 90501
-  _clearReward: 128
+  _clearReward: 88
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: edd1db5e8e57ac147a054fff9e9f85a3, type: 2}
     _count: 34

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90501_28.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90501_28.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 28
   _difficultyModifierId: 90501
-  _clearReward: 128
+  _clearReward: 88
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: edd1db5e8e57ac147a054fff9e9f85a3, type: 2}
     _count: 36

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90501_29.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90501_29.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 29
   _difficultyModifierId: 90501
-  _clearReward: 126
+  _clearReward: 86
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: edd1db5e8e57ac147a054fff9e9f85a3, type: 2}
     _count: 40

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90501_31.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90501_31.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 31
   _difficultyModifierId: 90501
-  _clearReward: 160
+  _clearReward: 130
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: d5a30689fa6723e49a28e6fc6ff5cd54, type: 2}
     _count: 25

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90501_32.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90501_32.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 32
   _difficultyModifierId: 90501
-  _clearReward: 157
+  _clearReward: 127
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: d5a30689fa6723e49a28e6fc6ff5cd54, type: 2}
     _count: 30

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90501_33.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90501_33.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 33
   _difficultyModifierId: 90501
-  _clearReward: 154
+  _clearReward: 124
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: d5a30689fa6723e49a28e6fc6ff5cd54, type: 2}
     _count: 30

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90501_34.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90501_34.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 34
   _difficultyModifierId: 90501
-  _clearReward: 166
+  _clearReward: 136
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: d5a30689fa6723e49a28e6fc6ff5cd54, type: 2}
     _count: 25

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90501_35.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90501_35.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 35
   _difficultyModifierId: 90501
-  _clearReward: 163
+  _clearReward: 133
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: d5a30689fa6723e49a28e6fc6ff5cd54, type: 2}
     _count: 30

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90501_36.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90501_36.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 36
   _difficultyModifierId: 90501
-  _clearReward: 160
+  _clearReward: 130
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: d5a30689fa6723e49a28e6fc6ff5cd54, type: 2}
     _count: 30

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90501_37.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90501_37.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 37
   _difficultyModifierId: 90501
-  _clearReward: 172
+  _clearReward: 142
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: edd1db5e8e57ac147a054fff9e9f85a3, type: 2}
     _count: 25

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90501_38.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90501_38.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 38
   _difficultyModifierId: 90501
-  _clearReward: 169
+  _clearReward: 139
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: edd1db5e8e57ac147a054fff9e9f85a3, type: 2}
     _count: 30

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90501_39.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90501_39.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 39
   _difficultyModifierId: 90501
-  _clearReward: 166
+  _clearReward: 136
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: edd1db5e8e57ac147a054fff9e9f85a3, type: 2}
     _count: 30

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90501_41.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90501_41.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 41
   _difficultyModifierId: 90501
-  _clearReward: 200
+  _clearReward: 160
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: d5a30689fa6723e49a28e6fc6ff5cd54, type: 2}
     _count: 20

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90501_42.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90501_42.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 42
   _difficultyModifierId: 90501
-  _clearReward: 192
+  _clearReward: 152
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: d5a30689fa6723e49a28e6fc6ff5cd54, type: 2}
     _count: 25

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90501_43.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90501_43.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 43
   _difficultyModifierId: 90501
-  _clearReward: 184
+  _clearReward: 144
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: d5a30689fa6723e49a28e6fc6ff5cd54, type: 2}
     _count: 30

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90501_44.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90501_44.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 44
   _difficultyModifierId: 90501
-  _clearReward: 176
+  _clearReward: 136
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: d5a30689fa6723e49a28e6fc6ff5cd54, type: 2}
     _count: 35

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90501_45.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90501_45.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 45
   _difficultyModifierId: 90501
-  _clearReward: 168
+  _clearReward: 128
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: d5a30689fa6723e49a28e6fc6ff5cd54, type: 2}
     _count: 40

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90501_46.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90501_46.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 46
   _difficultyModifierId: 90501
-  _clearReward: 160
+  _clearReward: 120
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: d5a30689fa6723e49a28e6fc6ff5cd54, type: 2}
     _count: 45

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90501_47.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90501_47.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 47
   _difficultyModifierId: 90501
-  _clearReward: 152
+  _clearReward: 112
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: d5a30689fa6723e49a28e6fc6ff5cd54, type: 2}
     _count: 50

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90501_48.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90501_48.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 48
   _difficultyModifierId: 90501
-  _clearReward: 144
+  _clearReward: 104
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: d5a30689fa6723e49a28e6fc6ff5cd54, type: 2}
     _count: 55

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90501_49.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90501_49.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 49
   _difficultyModifierId: 90501
-  _clearReward: 136
+  _clearReward: 96
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: d5a30689fa6723e49a28e6fc6ff5cd54, type: 2}
     _count: 60

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90502_11.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90502_11.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 11
   _difficultyModifierId: 90502
-  _clearReward: 72
+  _clearReward: 56
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: f044c3a810846ba4e88d00386bfe7824, type: 2}
     _count: 20

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90502_12.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90502_12.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 12
   _difficultyModifierId: 90502
-  _clearReward: 72
+  _clearReward: 56
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: f044c3a810846ba4e88d00386bfe7824, type: 2}
     _count: 24

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90502_13.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90502_13.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 13
   _difficultyModifierId: 90502
-  _clearReward: 72
+  _clearReward: 56
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: f044c3a810846ba4e88d00386bfe7824, type: 2}
     _count: 28

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90502_14.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90502_14.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 14
   _difficultyModifierId: 90502
-  _clearReward: 72
+  _clearReward: 56
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: f044c3a810846ba4e88d00386bfe7824, type: 2}
     _count: 32

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90502_15.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90502_15.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 15
   _difficultyModifierId: 90502
-  _clearReward: 72
+  _clearReward: 56
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: f044c3a810846ba4e88d00386bfe7824, type: 2}
     _count: 36

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90502_16.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90502_16.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 16
   _difficultyModifierId: 90502
-  _clearReward: 72
+  _clearReward: 56
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: f044c3a810846ba4e88d00386bfe7824, type: 2}
     _count: 40

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90502_17.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90502_17.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 17
   _difficultyModifierId: 90502
-  _clearReward: 70
+  _clearReward: 54
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: f044c3a810846ba4e88d00386bfe7824, type: 2}
     _count: 48

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90502_18.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90502_18.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 18
   _difficultyModifierId: 90502
-  _clearReward: 70
+  _clearReward: 54
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: f044c3a810846ba4e88d00386bfe7824, type: 2}
     _count: 52

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90502_19.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90502_19.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 19
   _difficultyModifierId: 90502
-  _clearReward: 69
+  _clearReward: 53
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: f044c3a810846ba4e88d00386bfe7824, type: 2}
     _count: 60

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90502_21.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90502_21.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 21
   _difficultyModifierId: 90502
-  _clearReward: 104
+  _clearReward: 72
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: edd1db5e8e57ac147a054fff9e9f85a3, type: 2}
     _count: 40

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90502_22.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90502_22.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 22
   _difficultyModifierId: 90502
-  _clearReward: 104
+  _clearReward: 72
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: edd1db5e8e57ac147a054fff9e9f85a3, type: 2}
     _count: 44

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90502_23.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90502_23.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 23
   _difficultyModifierId: 90502
-  _clearReward: 104
+  _clearReward: 72
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: edd1db5e8e57ac147a054fff9e9f85a3, type: 2}
     _count: 48

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90502_24.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90502_24.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 24
   _difficultyModifierId: 90502
-  _clearReward: 104
+  _clearReward: 72
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: edd1db5e8e57ac147a054fff9e9f85a3, type: 2}
     _count: 52

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90502_25.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90502_25.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 25
   _difficultyModifierId: 90502
-  _clearReward: 104
+  _clearReward: 72
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: edd1db5e8e57ac147a054fff9e9f85a3, type: 2}
     _count: 56

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90502_26.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90502_26.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 26
   _difficultyModifierId: 90502
-  _clearReward: 104
+  _clearReward: 72
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: edd1db5e8e57ac147a054fff9e9f85a3, type: 2}
     _count: 60

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90502_27.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90502_27.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 27
   _difficultyModifierId: 90502
-  _clearReward: 102
+  _clearReward: 70
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: edd1db5e8e57ac147a054fff9e9f85a3, type: 2}
     _count: 68

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90502_28.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90502_28.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 28
   _difficultyModifierId: 90502
-  _clearReward: 102
+  _clearReward: 70
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: edd1db5e8e57ac147a054fff9e9f85a3, type: 2}
     _count: 72

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90502_29.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90502_29.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 29
   _difficultyModifierId: 90502
-  _clearReward: 101
+  _clearReward: 69
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: edd1db5e8e57ac147a054fff9e9f85a3, type: 2}
     _count: 40

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90502_31.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90502_31.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 31
   _difficultyModifierId: 90502
-  _clearReward: 128
+  _clearReward: 104
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: d5a30689fa6723e49a28e6fc6ff5cd54, type: 2}
     _count: 50

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90502_32.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90502_32.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 32
   _difficultyModifierId: 90502
-  _clearReward: 126
+  _clearReward: 102
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: d5a30689fa6723e49a28e6fc6ff5cd54, type: 2}
     _count: 60

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90502_33.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90502_33.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 33
   _difficultyModifierId: 90502
-  _clearReward: 123
+  _clearReward: 99
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: d5a30689fa6723e49a28e6fc6ff5cd54, type: 2}
     _count: 60

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90502_34.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90502_34.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 34
   _difficultyModifierId: 90502
-  _clearReward: 133
+  _clearReward: 109
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: d5a30689fa6723e49a28e6fc6ff5cd54, type: 2}
     _count: 50

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90502_35.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90502_35.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 35
   _difficultyModifierId: 90502
-  _clearReward: 130
+  _clearReward: 106
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: d5a30689fa6723e49a28e6fc6ff5cd54, type: 2}
     _count: 60

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90502_36.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90502_36.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 36
   _difficultyModifierId: 90502
-  _clearReward: 128
+  _clearReward: 104
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: d5a30689fa6723e49a28e6fc6ff5cd54, type: 2}
     _count: 60

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90502_37.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90502_37.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 37
   _difficultyModifierId: 90502
-  _clearReward: 138
+  _clearReward: 114
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: edd1db5e8e57ac147a054fff9e9f85a3, type: 2}
     _count: 50

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90502_38.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90502_38.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 38
   _difficultyModifierId: 90502
-  _clearReward: 135
+  _clearReward: 111
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: edd1db5e8e57ac147a054fff9e9f85a3, type: 2}
     _count: 60

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90502_39.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90502_39.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 39
   _difficultyModifierId: 90502
-  _clearReward: 133
+  _clearReward: 109
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: edd1db5e8e57ac147a054fff9e9f85a3, type: 2}
     _count: 60

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90502_41.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90502_41.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 41
   _difficultyModifierId: 90502
-  _clearReward: 160
+  _clearReward: 128
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: d5a30689fa6723e49a28e6fc6ff5cd54, type: 2}
     _count: 40

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90502_42.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90502_42.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 42
   _difficultyModifierId: 90502
-  _clearReward: 154
+  _clearReward: 122
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: d5a30689fa6723e49a28e6fc6ff5cd54, type: 2}
     _count: 50

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90502_43.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90502_43.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 43
   _difficultyModifierId: 90502
-  _clearReward: 147
+  _clearReward: 115
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: d5a30689fa6723e49a28e6fc6ff5cd54, type: 2}
     _count: 60

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90502_44.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90502_44.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 44
   _difficultyModifierId: 90502
-  _clearReward: 141
+  _clearReward: 109
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: d5a30689fa6723e49a28e6fc6ff5cd54, type: 2}
     _count: 70

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90502_45.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90502_45.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 45
   _difficultyModifierId: 90502
-  _clearReward: 134
+  _clearReward: 102
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: d5a30689fa6723e49a28e6fc6ff5cd54, type: 2}
     _count: 80

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90502_46.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90502_46.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 46
   _difficultyModifierId: 90502
-  _clearReward: 128
+  _clearReward: 96
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: d5a30689fa6723e49a28e6fc6ff5cd54, type: 2}
     _count: 90

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90502_47.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90502_47.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 47
   _difficultyModifierId: 90502
-  _clearReward: 122
+  _clearReward: 90
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: d5a30689fa6723e49a28e6fc6ff5cd54, type: 2}
     _count: 100

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90502_48.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90502_48.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 48
   _difficultyModifierId: 90502
-  _clearReward: 115
+  _clearReward: 83
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: d5a30689fa6723e49a28e6fc6ff5cd54, type: 2}
     _count: 110

--- a/Bismuth/Assets/Data/Waves/Ruins/Wave_90502_49.asset
+++ b/Bismuth/Assets/Data/Waves/Ruins/Wave_90502_49.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 49
   _difficultyModifierId: 90502
-  _clearReward: 109
+  _clearReward: 77
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: d5a30689fa6723e49a28e6fc6ff5cd54, type: 2}
     _count: 120

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90500_11.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90500_11.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 11
   _difficultyModifierId: 90500
-  _clearReward: 90
+  _clearReward: 70
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 0debd030b327f5d4bb5bc8abdd0d7306, type: 2}
     _count: 10

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90500_12.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90500_12.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 12
   _difficultyModifierId: 90500
-  _clearReward: 90
+  _clearReward: 70
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 0debd030b327f5d4bb5bc8abdd0d7306, type: 2}
     _count: 12

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90500_13.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90500_13.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 13
   _difficultyModifierId: 90500
-  _clearReward: 90
+  _clearReward: 70
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 0debd030b327f5d4bb5bc8abdd0d7306, type: 2}
     _count: 14

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90500_14.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90500_14.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 14
   _difficultyModifierId: 90500
-  _clearReward: 90
+  _clearReward: 70
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 0debd030b327f5d4bb5bc8abdd0d7306, type: 2}
     _count: 16

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90500_15.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90500_15.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 15
   _difficultyModifierId: 90500
-  _clearReward: 90
+  _clearReward: 70
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 0debd030b327f5d4bb5bc8abdd0d7306, type: 2}
     _count: 18

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90500_16.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90500_16.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 16
   _difficultyModifierId: 90500
-  _clearReward: 90
+  _clearReward: 70
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 0debd030b327f5d4bb5bc8abdd0d7306, type: 2}
     _count: 20

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90500_17.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90500_17.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 17
   _difficultyModifierId: 90500
-  _clearReward: 88
+  _clearReward: 68
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 0debd030b327f5d4bb5bc8abdd0d7306, type: 2}
     _count: 24

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90500_18.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90500_18.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 18
   _difficultyModifierId: 90500
-  _clearReward: 88
+  _clearReward: 68
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 0debd030b327f5d4bb5bc8abdd0d7306, type: 2}
     _count: 26

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90500_19.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90500_19.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 19
   _difficultyModifierId: 90500
-  _clearReward: 86
+  _clearReward: 66
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 0debd030b327f5d4bb5bc8abdd0d7306, type: 2}
     _count: 30

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90500_21.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90500_21.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 21
   _difficultyModifierId: 90500
-  _clearReward: 130
+  _clearReward: 90
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: fb7723111f662cf4aa135aea892001e0, type: 2}
     _count: 20

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90500_22.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90500_22.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 22
   _difficultyModifierId: 90500
-  _clearReward: 130
+  _clearReward: 90
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: fb7723111f662cf4aa135aea892001e0, type: 2}
     _count: 22

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90500_23.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90500_23.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 23
   _difficultyModifierId: 90500
-  _clearReward: 130
+  _clearReward: 90
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: fb7723111f662cf4aa135aea892001e0, type: 2}
     _count: 24

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90500_24.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90500_24.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 24
   _difficultyModifierId: 90500
-  _clearReward: 130
+  _clearReward: 90
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: fb7723111f662cf4aa135aea892001e0, type: 2}
     _count: 26

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90500_25.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90500_25.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 25
   _difficultyModifierId: 90500
-  _clearReward: 130
+  _clearReward: 90
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: fb7723111f662cf4aa135aea892001e0, type: 2}
     _count: 28

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90500_26.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90500_26.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 26
   _difficultyModifierId: 90500
-  _clearReward: 130
+  _clearReward: 90
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: fb7723111f662cf4aa135aea892001e0, type: 2}
     _count: 30

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90500_27.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90500_27.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 27
   _difficultyModifierId: 90500
-  _clearReward: 128
+  _clearReward: 88
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: fb7723111f662cf4aa135aea892001e0, type: 2}
     _count: 34

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90500_28.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90500_28.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 28
   _difficultyModifierId: 90500
-  _clearReward: 128
+  _clearReward: 88
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: fb7723111f662cf4aa135aea892001e0, type: 2}
     _count: 36

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90500_29.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90500_29.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 29
   _difficultyModifierId: 90500
-  _clearReward: 126
+  _clearReward: 86
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: fb7723111f662cf4aa135aea892001e0, type: 2}
     _count: 40

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90501_11.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90501_11.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 11
   _difficultyModifierId: 90501
-  _clearReward: 90
+  _clearReward: 70
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 0debd030b327f5d4bb5bc8abdd0d7306, type: 2}
     _count: 10

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90501_12.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90501_12.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 12
   _difficultyModifierId: 90501
-  _clearReward: 90
+  _clearReward: 70
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 0debd030b327f5d4bb5bc8abdd0d7306, type: 2}
     _count: 12

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90501_13.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90501_13.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 13
   _difficultyModifierId: 90501
-  _clearReward: 90
+  _clearReward: 70
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 0debd030b327f5d4bb5bc8abdd0d7306, type: 2}
     _count: 14

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90501_14.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90501_14.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 14
   _difficultyModifierId: 90501
-  _clearReward: 90
+  _clearReward: 70
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 0debd030b327f5d4bb5bc8abdd0d7306, type: 2}
     _count: 16

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90501_15.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90501_15.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 15
   _difficultyModifierId: 90501
-  _clearReward: 90
+  _clearReward: 70
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 0debd030b327f5d4bb5bc8abdd0d7306, type: 2}
     _count: 18

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90501_16.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90501_16.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 16
   _difficultyModifierId: 90501
-  _clearReward: 90
+  _clearReward: 70
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 0debd030b327f5d4bb5bc8abdd0d7306, type: 2}
     _count: 20

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90501_17.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90501_17.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 17
   _difficultyModifierId: 90501
-  _clearReward: 88
+  _clearReward: 68
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 0debd030b327f5d4bb5bc8abdd0d7306, type: 2}
     _count: 24

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90501_18.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90501_18.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 18
   _difficultyModifierId: 90501
-  _clearReward: 88
+  _clearReward: 68
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 0debd030b327f5d4bb5bc8abdd0d7306, type: 2}
     _count: 26

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90501_19.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90501_19.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 19
   _difficultyModifierId: 90501
-  _clearReward: 86
+  _clearReward: 66
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 0debd030b327f5d4bb5bc8abdd0d7306, type: 2}
     _count: 30

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90501_21.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90501_21.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 21
   _difficultyModifierId: 90501
-  _clearReward: 130
+  _clearReward: 90
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: fb7723111f662cf4aa135aea892001e0, type: 2}
     _count: 20

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90501_22.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90501_22.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 22
   _difficultyModifierId: 90501
-  _clearReward: 130
+  _clearReward: 90
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: fb7723111f662cf4aa135aea892001e0, type: 2}
     _count: 22

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90501_23.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90501_23.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 23
   _difficultyModifierId: 90501
-  _clearReward: 130
+  _clearReward: 90
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: fb7723111f662cf4aa135aea892001e0, type: 2}
     _count: 24

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90501_24.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90501_24.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 24
   _difficultyModifierId: 90501
-  _clearReward: 130
+  _clearReward: 90
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: fb7723111f662cf4aa135aea892001e0, type: 2}
     _count: 26

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90501_25.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90501_25.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 25
   _difficultyModifierId: 90501
-  _clearReward: 130
+  _clearReward: 90
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: fb7723111f662cf4aa135aea892001e0, type: 2}
     _count: 28

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90501_26.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90501_26.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 26
   _difficultyModifierId: 90501
-  _clearReward: 130
+  _clearReward: 90
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: fb7723111f662cf4aa135aea892001e0, type: 2}
     _count: 30

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90501_27.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90501_27.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 27
   _difficultyModifierId: 90501
-  _clearReward: 128
+  _clearReward: 88
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: fb7723111f662cf4aa135aea892001e0, type: 2}
     _count: 34

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90501_28.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90501_28.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 28
   _difficultyModifierId: 90501
-  _clearReward: 128
+  _clearReward: 88
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: fb7723111f662cf4aa135aea892001e0, type: 2}
     _count: 36

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90501_29.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90501_29.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 29
   _difficultyModifierId: 90501
-  _clearReward: 126
+  _clearReward: 86
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: fb7723111f662cf4aa135aea892001e0, type: 2}
     _count: 40

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90501_31.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90501_31.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 31
   _difficultyModifierId: 90501
-  _clearReward: 160
+  _clearReward: 130
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 447480bab67bbd94893f119f43e86639, type: 2}
     _count: 25

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90501_32.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90501_32.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 32
   _difficultyModifierId: 90501
-  _clearReward: 157
+  _clearReward: 127
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 447480bab67bbd94893f119f43e86639, type: 2}
     _count: 30

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90501_33.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90501_33.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 33
   _difficultyModifierId: 90501
-  _clearReward: 154
+  _clearReward: 124
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 447480bab67bbd94893f119f43e86639, type: 2}
     _count: 30

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90501_34.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90501_34.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 34
   _difficultyModifierId: 90501
-  _clearReward: 166
+  _clearReward: 136
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 447480bab67bbd94893f119f43e86639, type: 2}
     _count: 25

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90501_35.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90501_35.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 35
   _difficultyModifierId: 90501
-  _clearReward: 163
+  _clearReward: 133
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 447480bab67bbd94893f119f43e86639, type: 2}
     _count: 30

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90501_36.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90501_36.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 36
   _difficultyModifierId: 90501
-  _clearReward: 160
+  _clearReward: 130
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 447480bab67bbd94893f119f43e86639, type: 2}
     _count: 30

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90501_37.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90501_37.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 37
   _difficultyModifierId: 90501
-  _clearReward: 172
+  _clearReward: 142
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 0debd030b327f5d4bb5bc8abdd0d7306, type: 2}
     _count: 25

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90501_38.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90501_38.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 38
   _difficultyModifierId: 90501
-  _clearReward: 169
+  _clearReward: 139
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 0debd030b327f5d4bb5bc8abdd0d7306, type: 2}
     _count: 30

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90501_39.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90501_39.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 39
   _difficultyModifierId: 90501
-  _clearReward: 166
+  _clearReward: 136
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 0debd030b327f5d4bb5bc8abdd0d7306, type: 2}
     _count: 30

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90501_41.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90501_41.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 41
   _difficultyModifierId: 90501
-  _clearReward: 200
+  _clearReward: 160
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 447480bab67bbd94893f119f43e86639, type: 2}
     _count: 20

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90501_42.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90501_42.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 42
   _difficultyModifierId: 90501
-  _clearReward: 192
+  _clearReward: 152
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 447480bab67bbd94893f119f43e86639, type: 2}
     _count: 25

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90501_43.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90501_43.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 43
   _difficultyModifierId: 90501
-  _clearReward: 184
+  _clearReward: 144
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 447480bab67bbd94893f119f43e86639, type: 2}
     _count: 30

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90501_44.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90501_44.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 44
   _difficultyModifierId: 90501
-  _clearReward: 176
+  _clearReward: 136
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 447480bab67bbd94893f119f43e86639, type: 2}
     _count: 35

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90501_45.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90501_45.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 45
   _difficultyModifierId: 90501
-  _clearReward: 168
+  _clearReward: 128
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 447480bab67bbd94893f119f43e86639, type: 2}
     _count: 40

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90501_46.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90501_46.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 46
   _difficultyModifierId: 90501
-  _clearReward: 160
+  _clearReward: 120
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 447480bab67bbd94893f119f43e86639, type: 2}
     _count: 45

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90501_47.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90501_47.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 47
   _difficultyModifierId: 90501
-  _clearReward: 152
+  _clearReward: 112
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 447480bab67bbd94893f119f43e86639, type: 2}
     _count: 50

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90501_48.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90501_48.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 48
   _difficultyModifierId: 90501
-  _clearReward: 144
+  _clearReward: 104
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 447480bab67bbd94893f119f43e86639, type: 2}
     _count: 55

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90501_49.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90501_49.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 49
   _difficultyModifierId: 90501
-  _clearReward: 136
+  _clearReward: 96
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 447480bab67bbd94893f119f43e86639, type: 2}
     _count: 60

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90502_11.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90502_11.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 11
   _difficultyModifierId: 90502
-  _clearReward: 72
+  _clearReward: 56
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 0debd030b327f5d4bb5bc8abdd0d7306, type: 2}
     _count: 20

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90502_12.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90502_12.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 12
   _difficultyModifierId: 90502
-  _clearReward: 72
+  _clearReward: 56
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 0debd030b327f5d4bb5bc8abdd0d7306, type: 2}
     _count: 24

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90502_13.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90502_13.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 13
   _difficultyModifierId: 90502
-  _clearReward: 72
+  _clearReward: 56
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 0debd030b327f5d4bb5bc8abdd0d7306, type: 2}
     _count: 28

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90502_14.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90502_14.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 14
   _difficultyModifierId: 90502
-  _clearReward: 72
+  _clearReward: 56
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 0debd030b327f5d4bb5bc8abdd0d7306, type: 2}
     _count: 32

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90502_15.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90502_15.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 15
   _difficultyModifierId: 90502
-  _clearReward: 72
+  _clearReward: 56
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 0debd030b327f5d4bb5bc8abdd0d7306, type: 2}
     _count: 36

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90502_16.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90502_16.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 16
   _difficultyModifierId: 90502
-  _clearReward: 72
+  _clearReward: 56
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 0debd030b327f5d4bb5bc8abdd0d7306, type: 2}
     _count: 40

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90502_17.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90502_17.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 17
   _difficultyModifierId: 90502
-  _clearReward: 70
+  _clearReward: 54
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 0debd030b327f5d4bb5bc8abdd0d7306, type: 2}
     _count: 48

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90502_18.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90502_18.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 18
   _difficultyModifierId: 90502
-  _clearReward: 70
+  _clearReward: 54
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 0debd030b327f5d4bb5bc8abdd0d7306, type: 2}
     _count: 52

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90502_19.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90502_19.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 19
   _difficultyModifierId: 90502
-  _clearReward: 69
+  _clearReward: 53
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 0debd030b327f5d4bb5bc8abdd0d7306, type: 2}
     _count: 60

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90502_21.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90502_21.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 21
   _difficultyModifierId: 90502
-  _clearReward: 104
+  _clearReward: 72
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: fb7723111f662cf4aa135aea892001e0, type: 2}
     _count: 40

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90502_22.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90502_22.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 22
   _difficultyModifierId: 90502
-  _clearReward: 104
+  _clearReward: 72
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: fb7723111f662cf4aa135aea892001e0, type: 2}
     _count: 44

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90502_23.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90502_23.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 23
   _difficultyModifierId: 90502
-  _clearReward: 104
+  _clearReward: 72
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: fb7723111f662cf4aa135aea892001e0, type: 2}
     _count: 48

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90502_24.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90502_24.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 24
   _difficultyModifierId: 90502
-  _clearReward: 104
+  _clearReward: 72
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: fb7723111f662cf4aa135aea892001e0, type: 2}
     _count: 52

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90502_25.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90502_25.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 25
   _difficultyModifierId: 90502
-  _clearReward: 104
+  _clearReward: 72
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: fb7723111f662cf4aa135aea892001e0, type: 2}
     _count: 56

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90502_26.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90502_26.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 26
   _difficultyModifierId: 90502
-  _clearReward: 104
+  _clearReward: 72
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: fb7723111f662cf4aa135aea892001e0, type: 2}
     _count: 60

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90502_27.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90502_27.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 27
   _difficultyModifierId: 90502
-  _clearReward: 102
+  _clearReward: 70
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: fb7723111f662cf4aa135aea892001e0, type: 2}
     _count: 68

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90502_28.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90502_28.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 28
   _difficultyModifierId: 90502
-  _clearReward: 102
+  _clearReward: 70
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: fb7723111f662cf4aa135aea892001e0, type: 2}
     _count: 72

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90502_29.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90502_29.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 29
   _difficultyModifierId: 90502
-  _clearReward: 101
+  _clearReward: 69
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: fb7723111f662cf4aa135aea892001e0, type: 2}
     _count: 40

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90502_31.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90502_31.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 31
   _difficultyModifierId: 90502
-  _clearReward: 128
+  _clearReward: 104
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 447480bab67bbd94893f119f43e86639, type: 2}
     _count: 50

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90502_32.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90502_32.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 32
   _difficultyModifierId: 90502
-  _clearReward: 126
+  _clearReward: 102
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 447480bab67bbd94893f119f43e86639, type: 2}
     _count: 60

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90502_33.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90502_33.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 33
   _difficultyModifierId: 90502
-  _clearReward: 123
+  _clearReward: 99
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 447480bab67bbd94893f119f43e86639, type: 2}
     _count: 60

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90502_34.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90502_34.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 34
   _difficultyModifierId: 90502
-  _clearReward: 133
+  _clearReward: 109
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 447480bab67bbd94893f119f43e86639, type: 2}
     _count: 50

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90502_35.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90502_35.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 35
   _difficultyModifierId: 90502
-  _clearReward: 130
+  _clearReward: 106
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 447480bab67bbd94893f119f43e86639, type: 2}
     _count: 60

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90502_36.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90502_36.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 36
   _difficultyModifierId: 90502
-  _clearReward: 128
+  _clearReward: 104
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 447480bab67bbd94893f119f43e86639, type: 2}
     _count: 60

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90502_37.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90502_37.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 37
   _difficultyModifierId: 90502
-  _clearReward: 138
+  _clearReward: 114
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 0debd030b327f5d4bb5bc8abdd0d7306, type: 2}
     _count: 50

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90502_38.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90502_38.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 38
   _difficultyModifierId: 90502
-  _clearReward: 135
+  _clearReward: 111
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 0debd030b327f5d4bb5bc8abdd0d7306, type: 2}
     _count: 60

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90502_39.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90502_39.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 39
   _difficultyModifierId: 90502
-  _clearReward: 133
+  _clearReward: 109
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 0debd030b327f5d4bb5bc8abdd0d7306, type: 2}
     _count: 60

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90502_41.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90502_41.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 41
   _difficultyModifierId: 90502
-  _clearReward: 160
+  _clearReward: 128
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 447480bab67bbd94893f119f43e86639, type: 2}
     _count: 40

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90502_42.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90502_42.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 42
   _difficultyModifierId: 90502
-  _clearReward: 154
+  _clearReward: 122
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 447480bab67bbd94893f119f43e86639, type: 2}
     _count: 50

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90502_43.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90502_43.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 43
   _difficultyModifierId: 90502
-  _clearReward: 147
+  _clearReward: 115
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 447480bab67bbd94893f119f43e86639, type: 2}
     _count: 60

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90502_44.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90502_44.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 44
   _difficultyModifierId: 90502
-  _clearReward: 141
+  _clearReward: 109
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 447480bab67bbd94893f119f43e86639, type: 2}
     _count: 70

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90502_45.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90502_45.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 45
   _difficultyModifierId: 90502
-  _clearReward: 134
+  _clearReward: 102
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 447480bab67bbd94893f119f43e86639, type: 2}
     _count: 80

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90502_46.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90502_46.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 46
   _difficultyModifierId: 90502
-  _clearReward: 128
+  _clearReward: 96
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 447480bab67bbd94893f119f43e86639, type: 2}
     _count: 90

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90502_47.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90502_47.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 47
   _difficultyModifierId: 90502
-  _clearReward: 122
+  _clearReward: 90
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 447480bab67bbd94893f119f43e86639, type: 2}
     _count: 100

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90502_48.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90502_48.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 48
   _difficultyModifierId: 90502
-  _clearReward: 115
+  _clearReward: 83
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 447480bab67bbd94893f119f43e86639, type: 2}
     _count: 110

--- a/Bismuth/Assets/Data/Waves/Village/Wave_90502_49.asset
+++ b/Bismuth/Assets/Data/Waves/Village/Wave_90502_49.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::WaveDataSO
   _waveNumber: 49
   _difficultyModifierId: 90502
-  _clearReward: 109
+  _clearReward: 77
   _spawnEntries:
   - _monsterData: {fileID: 11400000, guid: 447480bab67bbd94893f119f43e86639, type: 2}
     _count: 120

--- a/Bismuth/Assets/Prefabs/조경민/Canvas/CombatCanvas.prefab
+++ b/Bismuth/Assets/Prefabs/조경민/Canvas/CombatCanvas.prefab
@@ -120,7 +120,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
-  m_AnchoredPosition: {x: 55, y: -260}
+  m_AnchoredPosition: {x: 55, y: -480}
   m_SizeDelta: {x: -70, y: 50}
   m_Pivot: {x: 0, y: 1}
 --- !u!222 &6240001640981655528
@@ -4490,7 +4490,7 @@ GameObject:
   - component: {fileID: 3777967908617398716}
   - component: {fileID: 4043493037948156179}
   m_Layer: 5
-  m_Name: DescriptionText
+  m_Name: StatText
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -4543,7 +4543,11 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: Description
+  m_text: 'Attack : 9999
+
+    AS : 1000/1s
+
+    Range : 9.9'
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 2775cad2976b83541ac05203406cbcce, type: 2}
   m_sharedMaterial: {fileID: 850630175686753345, guid: 2775cad2976b83541ac05203406cbcce, type: 2}
@@ -4552,8 +4556,8 @@ MonoBehaviour:
   m_fontMaterials: []
   m_fontColor32:
     serializedVersion: 2
-    rgba: 4278190080
-  m_fontColor: {r: 0, g: 0, b: 0, a: 1}
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
   m_enableVertexGradient: 0
   m_colorMode: 3
   m_fontColorGradient:
@@ -4577,8 +4581,8 @@ MonoBehaviour:
   m_fontSizeMin: 18
   m_fontSizeMax: 72
   m_fontStyle: 0
-  m_HorizontalAlignment: 1
-  m_VerticalAlignment: 256
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
   m_characterHorizontalScale: 1
@@ -4839,7 +4843,7 @@ GameObject:
   - component: {fileID: 9048443154291311257}
   - component: {fileID: 1660178281704504457}
   m_Layer: 5
-  m_Name: StatText
+  m_Name: AttackTypeText
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -4892,9 +4896,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: 'Attack 9999
-
-    AS 1000/1s'
+  m_text: "[ \uD0C0\uAC9F\uD305 ]"
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 2775cad2976b83541ac05203406cbcce, type: 2}
   m_sharedMaterial: {fileID: 850630175686753345, guid: 2775cad2976b83541ac05203406cbcce, type: 2}
@@ -4921,8 +4923,8 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 32
-  m_fontSizeBase: 32
+  m_fontSize: 30
+  m_fontSizeBase: 30
   m_fontWeight: 400
   m_enableAutoSizing: 0
   m_fontSizeMin: 18
@@ -6884,9 +6886,9 @@ RectTransform:
   - {fileID: 9041947050038428394}
   - {fileID: 7294647724953289629}
   - {fileID: 5397058729295637260}
+  - {fileID: 70095490769915383}
   - {fileID: 2337337984215818483}
   - {fileID: 6570619411136239109}
-  - {fileID: 70095490769915383}
   m_Father: {fileID: 4671902234174367310}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 1}
@@ -6947,10 +6949,10 @@ MonoBehaviour:
   _nameText: {fileID: 6384255959146688795}
   _levelText: {fileID: 2727994119247439457}
   _tierText: {fileID: 7582282862169484090}
-  _statText: {fileID: 1660178281704504457}
+  _attackTypeText: {fileID: 1660178281704504457}
   _upgradeText: {fileID: 8854068859752104680}
   _sellText: {fileID: 530174695172451064}
-  _descriptionText: {fileID: 4043493037948156179}
+  _statText: {fileID: 4043493037948156179}
   _upgradeGoldText: {fileID: 5752946206129212212}
   _sellGoldText: {fileID: 1357840916801670966}
   _tagGroup: {fileID: 7294647724953289629}
@@ -7667,7 +7669,7 @@ GameObject:
   - component: {fileID: 1095142422955485730}
   - component: {fileID: 4685737682930616511}
   m_Layer: 5
-  m_Name: StatsBackground
+  m_Name: AttackTypeBackground
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -7690,8 +7692,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 0}
-  m_AnchoredPosition: {x: 0, y: 449}
-  m_SizeDelta: {x: -76, y: 97.33}
+  m_AnchoredPosition: {x: 0, y: 450}
+  m_SizeDelta: {x: -76, y: 70}
   m_Pivot: {x: 0.5, y: 1}
 --- !u!222 &1095142422955485730
 CanvasRenderer:
@@ -8684,7 +8686,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -55, y: -260}
+  m_AnchoredPosition: {x: -55, y: -480}
   m_SizeDelta: {x: -75, y: 50}
   m_Pivot: {x: 1, y: 1}
 --- !u!222 &186506641356292538
@@ -8995,7 +8997,7 @@ GameObject:
   - component: {fileID: 2279386200943954830}
   - component: {fileID: 412949653697986544}
   m_Layer: 5
-  m_Name: Description
+  m_Name: StatBackground
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -9018,8 +9020,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 0}
-  m_AnchoredPosition: {x: 0, y: 25}
-  m_SizeDelta: {x: -76, y: 230}
+  m_AnchoredPosition: {x: 0, y: 145}
+  m_SizeDelta: {x: -76, y: 210}
   m_Pivot: {x: 0.5, y: 0}
 --- !u!222 &2279386200943954830
 CanvasRenderer:

--- a/Bismuth/Assets/Prefabs/조경민/Canvas/CombatCanvas.prefab
+++ b/Bismuth/Assets/Prefabs/조경민/Canvas/CombatCanvas.prefab
@@ -2122,6 +2122,8 @@ RectTransform:
   m_Children:
   - {fileID: 7034476997768463337}
   - {fileID: 4671902234174367310}
+  - {fileID: 5774858148132528981}
+  - {fileID: 1865525099639053393}
   - {fileID: 6447462680860066335}
   - {fileID: 318995245403659007}
   - {fileID: 6463504754060551629}
@@ -2586,6 +2588,149 @@ MonoBehaviour:
     rgba: 4294967295
   m_fontSize: 40
   m_fontSizeBase: 40
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_characterHorizontalScale: 1
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &1613692466841712486
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 711280826120387776}
+  - component: {fileID: 2432836007377998316}
+  - component: {fileID: 9113689169743475376}
+  m_Layer: 5
+  m_Name: SummonChanceText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &711280826120387776
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1613692466841712486}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2741369917683161816}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2432836007377998316
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1613692466841712486}
+  m_CullTransparentMesh: 1
+--- !u!114 &9113689169743475376
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1613692466841712486}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: '1Tier 00%
+
+    2Tier 00%
+
+    3Tier 00%
+
+    4Tier 00%'
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 3853a03fd498e8646804bd749fe97536, type: 2}
+  m_sharedMaterial: {fileID: 3185106437989493457, guid: 3853a03fd498e8646804bd749fe97536, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4278190080
+  m_fontColor: {r: 0, g: 0, b: 0, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 30
+  m_fontSizeBase: 30
   m_fontWeight: 400
   m_enableAutoSizing: 0
   m_fontSizeMin: 18
@@ -4619,6 +4764,82 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &2748810964999528991
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2741369917683161816}
+  - component: {fileID: 7400601496354443018}
+  - component: {fileID: 3382810460249723820}
+  m_Layer: 5
+  m_Name: SummonChanceTooltip
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &2741369917683161816
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2748810964999528991}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 711280826120387776}
+  m_Father: {fileID: 1865525099639053393}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 150}
+  m_SizeDelta: {x: 300, y: 200}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &7400601496354443018
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2748810964999528991}
+  m_CullTransparentMesh: 1
+--- !u!114 &3382810460249723820
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2748810964999528991}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 3b8c1c0b6c3acd64bb6e8b72d56ac656, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 0.5
 --- !u!1 &2930281196402904962
 GameObject:
   m_ObjectHideFlags: 0
@@ -7907,8 +8128,6 @@ RectTransform:
   - {fileID: 1008124524574056623}
   - {fileID: 1246342585117459169}
   - {fileID: 1245277954664257293}
-  - {fileID: 5774858148132528981}
-  - {fileID: 1865525099639053393}
   - {fileID: 1984760028688070027}
   m_Father: {fileID: 5873718309042736905}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -9325,11 +9544,11 @@ RectTransform:
   m_Children:
   - {fileID: 8598084172844224503}
   - {fileID: 1834131414187979946}
-  m_Father: {fileID: 4671902234174367310}
+  m_Father: {fileID: 5873718309042736905}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0}
   m_AnchorMax: {x: 0.5, y: 0}
-  m_AnchoredPosition: {x: -120, y: 60}
+  m_AnchoredPosition: {x: 552, y: 60}
   m_SizeDelta: {x: 180, y: 65}
   m_Pivot: {x: 0.5, y: 0}
 --- !u!222 &3965880455907057121
@@ -10250,6 +10469,7 @@ GameObject:
   - component: {fileID: 7321673112020738318}
   - component: {fileID: 5731049783912212446}
   - component: {fileID: 4322819893751391658}
+  - component: {fileID: 3220925294891187182}
   m_Layer: 5
   m_Name: UpgradeButton
   m_TagString: Untagged
@@ -10264,18 +10484,19 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8517449017896063066}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 5311360450322621657}
   - {fileID: 5800760851560756342}
-  m_Father: {fileID: 4671902234174367310}
+  - {fileID: 2741369917683161816}
+  m_Father: {fileID: 5873718309042736905}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0}
   m_AnchorMax: {x: 0.5, y: 0}
-  m_AnchoredPosition: {x: 120, y: 60}
+  m_AnchoredPosition: {x: 792, y: 60}
   m_SizeDelta: {x: 180, y: 65}
   m_Pivot: {x: 0.5, y: 0}
 --- !u!222 &7321673112020738318
@@ -10372,6 +10593,21 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
+--- !u!114 &3220925294891187182
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8517449017896063066}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 44ba123f4320b5240b3abea3ffb9d4af, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::SummonChanceUI
+  _summonChanceTooltip: {fileID: 2748810964999528991}
+  _summonChanceText: {fileID: 9113689169743475376}
+  _summonChanceSO: {fileID: 11400000, guid: 78cd8cc80ec1d984e9375d6e88f08fce, type: 2}
 --- !u!1 &8729813033305429777
 GameObject:
   m_ObjectHideFlags: 0

--- a/Bismuth/Assets/Prefabs/조경민/Canvas/CombatCanvas.prefab
+++ b/Bismuth/Assets/Prefabs/조경민/Canvas/CombatCanvas.prefab
@@ -2122,8 +2122,6 @@ RectTransform:
   m_Children:
   - {fileID: 7034476997768463337}
   - {fileID: 4671902234174367310}
-  - {fileID: 5774858148132528981}
-  - {fileID: 1865525099639053393}
   - {fileID: 6447462680860066335}
   - {fileID: 318995245403659007}
   - {fileID: 6463504754060551629}
@@ -4795,11 +4793,11 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 711280826120387776}
-  m_Father: {fileID: 1865525099639053393}
+  m_Father: {fileID: 5774858148132528981}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 150}
+  m_AnchoredPosition: {x: -340, y: 36}
   m_SizeDelta: {x: 300, y: 200}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &7400601496354443018
@@ -8129,6 +8127,8 @@ RectTransform:
   - {fileID: 1246342585117459169}
   - {fileID: 1245277954664257293}
   - {fileID: 1984760028688070027}
+  - {fileID: 5774858148132528981}
+  - {fileID: 1865525099639053393}
   m_Father: {fileID: 5873718309042736905}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.7, y: 0}
@@ -9523,6 +9523,7 @@ GameObject:
   - component: {fileID: 3965880455907057121}
   - component: {fileID: 5116400270999336526}
   - component: {fileID: 3695510818756753951}
+  - component: {fileID: 4722787180636780257}
   m_Layer: 5
   m_Name: DrawButton
   m_TagString: Untagged
@@ -9544,11 +9545,12 @@ RectTransform:
   m_Children:
   - {fileID: 8598084172844224503}
   - {fileID: 1834131414187979946}
-  m_Father: {fileID: 5873718309042736905}
+  - {fileID: 2741369917683161816}
+  m_Father: {fileID: 4671902234174367310}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0}
   m_AnchorMax: {x: 0.5, y: 0}
-  m_AnchoredPosition: {x: 552, y: 60}
+  m_AnchoredPosition: {x: -120, y: 60}
   m_SizeDelta: {x: 180, y: 65}
   m_Pivot: {x: 0.5, y: 0}
 --- !u!222 &3965880455907057121
@@ -9645,6 +9647,21 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
+--- !u!114 &4722787180636780257
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7371931740057641824}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 44ba123f4320b5240b3abea3ffb9d4af, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::SummonChanceUI
+  _summonChanceTooltip: {fileID: 2748810964999528991}
+  _summonChanceText: {fileID: 9113689169743475376}
+  _summonChanceSO: {fileID: 11400000, guid: 78cd8cc80ec1d984e9375d6e88f08fce, type: 2}
 --- !u!1 &7375233688767340423
 GameObject:
   m_ObjectHideFlags: 0
@@ -10469,7 +10486,6 @@ GameObject:
   - component: {fileID: 7321673112020738318}
   - component: {fileID: 5731049783912212446}
   - component: {fileID: 4322819893751391658}
-  - component: {fileID: 3220925294891187182}
   m_Layer: 5
   m_Name: UpgradeButton
   m_TagString: Untagged
@@ -10491,12 +10507,11 @@ RectTransform:
   m_Children:
   - {fileID: 5311360450322621657}
   - {fileID: 5800760851560756342}
-  - {fileID: 2741369917683161816}
-  m_Father: {fileID: 5873718309042736905}
+  m_Father: {fileID: 4671902234174367310}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0}
   m_AnchorMax: {x: 0.5, y: 0}
-  m_AnchoredPosition: {x: 792, y: 60}
+  m_AnchoredPosition: {x: 120, y: 60}
   m_SizeDelta: {x: 180, y: 65}
   m_Pivot: {x: 0.5, y: 0}
 --- !u!222 &7321673112020738318
@@ -10593,21 +10608,6 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
---- !u!114 &3220925294891187182
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8517449017896063066}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 44ba123f4320b5240b3abea3ffb9d4af, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: Assembly-CSharp::SummonChanceUI
-  _summonChanceTooltip: {fileID: 2748810964999528991}
-  _summonChanceText: {fileID: 9113689169743475376}
-  _summonChanceSO: {fileID: 11400000, guid: 78cd8cc80ec1d984e9375d6e88f08fce, type: 2}
 --- !u!1 &8729813033305429777
 GameObject:
   m_ObjectHideFlags: 0
@@ -11800,6 +11800,22 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 4671902234174367310}
     m_Modifications:
+    - target: {fileID: 837994929786080685, guid: e09a91c4f5b229648bafec4f373328f4, type: 3}
+      propertyPath: m_Padding.m_Top
+      value: 30
+      objectReference: {fileID: 0}
+    - target: {fileID: 837994929786080685, guid: e09a91c4f5b229648bafec4f373328f4, type: 3}
+      propertyPath: m_Padding.m_Left
+      value: 40
+      objectReference: {fileID: 0}
+    - target: {fileID: 837994929786080685, guid: e09a91c4f5b229648bafec4f373328f4, type: 3}
+      propertyPath: m_Padding.m_Right
+      value: 40
+      objectReference: {fileID: 0}
+    - target: {fileID: 837994929786080685, guid: e09a91c4f5b229648bafec4f373328f4, type: 3}
+      propertyPath: m_Padding.m_Bottom
+      value: 30
+      objectReference: {fileID: 0}
     - target: {fileID: 1409778748671384357, guid: e09a91c4f5b229648bafec4f373328f4, type: 3}
       propertyPath: m_AnchorMax.x
       value: 0
@@ -11823,6 +11839,22 @@ PrefabInstance:
     - target: {fileID: 5333107224250211509, guid: e09a91c4f5b229648bafec4f373328f4, type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6665904842207605136, guid: e09a91c4f5b229648bafec4f373328f4, type: 3}
+      propertyPath: m_Type
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6665904842207605136, guid: e09a91c4f5b229648bafec4f373328f4, type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 3b8c1c0b6c3acd64bb6e8b72d56ac656, type: 3}
+    - target: {fileID: 6665904842207605136, guid: e09a91c4f5b229648bafec4f373328f4, type: 3}
+      propertyPath: m_Color.a
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6665904842207605136, guid: e09a91c4f5b229648bafec4f373328f4, type: 3}
+      propertyPath: m_PixelsPerUnitMultiplier
+      value: 0.5
       objectReference: {fileID: 0}
     - target: {fileID: 7758726637310933059, guid: e09a91c4f5b229648bafec4f373328f4, type: 3}
       propertyPath: m_Pivot.x

--- a/Bismuth/Assets/Scenes/Test/Test.unity
+++ b/Bismuth/Assets/Scenes/Test/Test.unity
@@ -1861,6 +1861,10 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7012402871630413712, guid: 0d421f50ae089d34aa77d042e4fae853, type: 3}
+      propertyPath: _holdDuration
+      value: 0.312
+      objectReference: {fileID: 0}
+    - target: {fileID: 7012402871630413712, guid: 0d421f50ae089d34aa77d042e4fae853, type: 3}
       propertyPath: unitInfoPanel
       value: 
       objectReference: {fileID: 1436887454}

--- a/Bismuth/Assets/Scenes/Title Scene.unity
+++ b/Bismuth/Assets/Scenes/Title Scene.unity
@@ -264,9 +264,21 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 289124883089010408, guid: 6f5827745566e904dbc0e8d260b66451, type: 3}
+      propertyPath: _imageScale
+      value: 0.8
+      objectReference: {fileID: 0}
     - target: {fileID: 500667591796761450, guid: 6f5827745566e904dbc0e8d260b66451, type: 3}
       propertyPath: m_Name
       value: TitleCanvas
+      objectReference: {fileID: 0}
+    - target: {fileID: 3821047672999219481, guid: 6f5827745566e904dbc0e8d260b66451, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3821047672999219481, guid: 6f5827745566e904dbc0e8d260b66451, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5057742892756853211, guid: 6f5827745566e904dbc0e8d260b66451, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Target

--- a/Bismuth/Assets/Scripts/박승훈/Combine/Combine Manager.cs
+++ b/Bismuth/Assets/Scripts/박승훈/Combine/Combine Manager.cs
@@ -75,8 +75,6 @@ public class CombineManager : MonoBehaviour
         
         // 마지막에서 두번 째 : 결과 유닛 ID
         int resultUnitId = recipe[length - 2];
-        // 앞쪽 인덱스 재료 유닛들
-        int sourceUnitCount = length - 2;
         
         UnitData data = null;
         
@@ -95,53 +93,93 @@ public class CombineManager : MonoBehaviour
             DebugTool.Log($"{resultUnitId} : 결과 유닛을 찾지 못했습니다.", DebugType.Combine, this);
             return false;
         }
-
-        // 소비할 유닛 목록
-        List<TowerUnit> consumeTargets = new();
-        // 이미 소비한 유닛 중복 선택 방지
-        HashSet<TowerUnit> selectUnits = new();
         
-        // 재료 유닛 필요한 만큼 찾기
-        for (int i = 0; i < sourceUnitCount; i++)
-        {
-            int needId = recipe[i];
-            TowerUnit foundTower = null;
-            
-            foreach (SummonUnit.SummonedTowerRecord unit in _summonUnit.OwnedTowers)
-            {
-                if(unit.towerUnit == null)
-                    continue;
-                if (unit.Id != needId)
-                    continue;
-                if (selectUnits.Contains(unit.towerUnit))
-                    continue;
-                
-                foundTower = unit.towerUnit;
-                break;
-            }
-
-            if (foundTower == null)
-            {
-                DebugTool.Warnning($"재료유닛 ID {needId} 이(가) 부족합니다.", DebugType.Combine, this);
-                return false;
-            }
-            selectUnits.Add(foundTower);
-            consumeTargets.Add(foundTower);
-        }
+        // 재료 유닛 선택
+        if (!TryGetConsumeTargets(recipe, out List<TowerUnit> consumeTargets))
+            return false;
         
-        // 찾은 필요 재료들을 제거
+        // 선택된 재료 유닛 제거
         foreach (TowerUnit unit in consumeTargets)
         {
             _summonManager.DespawnUnit(unit);
         }
-        
-        DebugTool.Log($"{resultUnitId} 생성",  DebugType.Combine, this);
         
         // 결과 유닛 생성
         _summonManager.SummonCombineUnit(data);
         return true;
     }
     
+    // 소모될 유닛 우선순위에 의해 선택
+    private bool TryGetConsumeTargets(int[] recipe, out List<TowerUnit> consumeTargets)
+    {
+        consumeTargets = new List<TowerUnit>();
+
+        // recipe 구조
+        // [재료1,2,3 | 결과유닛ID | 조합가능여부]
+        int sourceUnitCount = recipe.Length - 2;
+
+        // 레시피에서 필요한 재료 개수 집계
+        Dictionary<int, int> requiredCounts = new();
+
+        for (int i = 0; i < sourceUnitCount; i++)
+        {
+            int sourceId = recipe[i];
+
+            if (requiredCounts.ContainsKey(sourceId))
+                requiredCounts[sourceId]++;
+            else
+                requiredCounts.Add(sourceId, 1);
+        }
+
+        // 각 재료 ID마다 후보를 모아서
+        // Level 낮은 순 -> 먼저 소환된 순으로 정렬 후 필요한 개수만큼 선택
+        foreach (var pair in requiredCounts)
+        {
+            int needId = pair.Key;
+            int needCount = pair.Value;
+
+            List<SummonUnit.SummonedTowerRecord> candidates = new();
+
+            foreach (var record in _summonUnit.OwnedTowers)
+            {
+                if (record == null)
+                    continue;
+                if (record.towerUnit == null)
+                    continue;
+                if (record.Id != needId)
+                    continue;
+
+                candidates.Add(record);
+            }
+
+            candidates.Sort((a, b) =>
+            {
+                int levelA = a.unitStat != null ? a.unitStat.Level : int.MaxValue;
+                int levelB = b.unitStat != null ? b.unitStat.Level : int.MaxValue;
+
+                // 1. 강화 안 된 유닛 우선 소모
+                if (levelA != levelB)
+                    return levelA.CompareTo(levelB);
+
+                // 2. 같으면 먼저 소환된 유닛 우선 소모
+                return a.summonIndex.CompareTo(b.summonIndex);
+            });
+
+            if (candidates.Count < needCount)
+            {
+                DebugTool.Warnning($"재료유닛 ID {needId} 이(가) {needCount}개 필요하지만 부족합니다.", DebugType.Combine, this);
+                consumeTargets = null;
+                return false;
+            }
+
+            for (int i = 0; i < needCount; i++)
+            {
+                consumeTargets.Add(candidates[i].towerUnit);
+            }
+        }
+
+        return true;
+    }
 
     // 보유한 유닛으로 조합 가능 여부 판단
     public bool CanCombine(CombineData recipe)
@@ -219,6 +257,8 @@ public class CombineManager : MonoBehaviour
             _ownedUnitCounts.Remove(unitId);
     }
     
+    // 합성 목록 리스트 정렬
+    // 합성 가능한 순, 유닛 ID 가 높은 순으로 정렬
     private List<int> GetSortedRecipeIndices()
     {
         List<int> result = new();

--- a/Bismuth/Assets/Scripts/박승훈/Player/Player Data Manager.cs
+++ b/Bismuth/Assets/Scripts/박승훈/Player/Player Data Manager.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Events;
@@ -22,15 +23,16 @@ public class PlayerDataManager : MonoBehaviour
     
     [Tooltip("현재 베이스 체력")]
     [SerializeField] private int _currentBaseHealth;
-    
+
+    public event Action OnLevelChanged;
+
     public int Level
     {
         get => _level;
         set
         {
             _level = value;
-            _controlPanelUI.RefreshLevel();
-            _controlPanelUI.RefreshUpgradeGold();
+            OnLevelChanged?.Invoke();
         }
     }
 

--- a/Bismuth/Assets/Scripts/박승훈/Player/Player UI Controller.cs
+++ b/Bismuth/Assets/Scripts/박승훈/Player/Player UI Controller.cs
@@ -23,8 +23,8 @@ public class PlayerUIController : MonoBehaviour
     private readonly int MAX_UNIT_LEVEL = 20;
     private readonly int COMBINE_GOLD = 50;
     private readonly int SUMMON_GOLD = 50;
-    private readonly int[] SELL_GOLD_BY_TIER = { 20, 40, 50, 200 };
-    private readonly int[] PLAYER_UPGRADE_GOLD = { 110, 220, 330, 440, 550 };
+    private readonly int[] SELL_GOLD_BY_TIER = { 10, 20, 30, 50 };
+    private readonly int[] PLAYER_UPGRADE_GOLD = { 110, 220, 330, 440, 1100 };
 
     public int MaxUnitLevel => MAX_UNIT_LEVEL;
 

--- a/Bismuth/Assets/Scripts/박승훈/Player/Player UI Controller.cs
+++ b/Bismuth/Assets/Scripts/박승훈/Player/Player UI Controller.cs
@@ -76,7 +76,7 @@ public class PlayerUIController : MonoBehaviour
             return;
         }
 
-        int payback = stat.Level * 10;
+        int payback = (stat.Level - 1) * 10;
 
         int sellGold = SellUnit(payback, stat.Tier);
 

--- a/Bismuth/Assets/Scripts/박승훈/Player/Player UI Controller.cs
+++ b/Bismuth/Assets/Scripts/박승훈/Player/Player UI Controller.cs
@@ -280,7 +280,7 @@ public class PlayerUIController : MonoBehaviour
     }
 
     public int GetSellGold(UnitStat stat)
-        => SellUnit(stat.Level * 10, stat.Tier);
+        => SellUnit((stat.Level - 1) * 10, stat.Tier);
 
 
     private void Init()

--- a/Bismuth/Assets/Scripts/이상현/Monster/Core/MonsterMover.cs
+++ b/Bismuth/Assets/Scripts/이상현/Monster/Core/MonsterMover.cs
@@ -20,6 +20,9 @@ public class MonsterMover : MonoBehaviour
     private bool _isPathCompleted;
     private bool _isSlowed;
 
+    private SpriteColorTint _colorTint;
+    private static readonly Color SlowTintColor = new Color(0.5f, 0.5f, 1f, 1f);
+
     public bool IsMoving { get; private set; }
     public Vector2 MoveDirection { get; private set; }
     public bool IsSlowed => _isSlowed;
@@ -46,6 +49,7 @@ public class MonsterMover : MonoBehaviour
         _isInitialized = false;
         _isPathCompleted = false;
         _isSlowed = false;
+        _colorTint?.Remove();
     }
 
     private void FixedUpdate()
@@ -90,7 +94,7 @@ public class MonsterMover : MonoBehaviour
         transform.position = startPosition;
 
         _isInitialized = true;
-
+        _colorTint = new SpriteColorTint(gameObject);
 
         if (_path.WaypointCount <= 1) CompletePath();
     }
@@ -104,6 +108,7 @@ public class MonsterMover : MonoBehaviour
         float clampedPercent = Mathf.Clamp(percent, 0f, 100f);
         _moveSpeed = _baseSpeed * (1f - clampedPercent * 0.01f);
         _isSlowed = true;
+        _colorTint?.Apply(SlowTintColor);
 
         DebugTool.Log(
             $"이동속도 감소 적용 | base={_baseSpeed:F2}, slow={clampedPercent:F1}%, current={_moveSpeed:F2}",
@@ -118,6 +123,7 @@ public class MonsterMover : MonoBehaviour
 
         _moveSpeed = _baseSpeed;
         _isSlowed = false;
+        _colorTint?.Remove();
 
         DebugTool.Log(
             $"이동속도 감소 해제 | 복원 속도={_baseSpeed:F2}",

--- a/Bismuth/Assets/Scripts/이수형/BoardSystem/TowerLongPressDragHandler.cs
+++ b/Bismuth/Assets/Scripts/이수형/BoardSystem/TowerLongPressDragHandler.cs
@@ -12,6 +12,7 @@ public class TowerLongPressDragHandler : MonoBehaviour
 
     [Header("Long Press")]
     [SerializeField] private float holdDuration = 0.5f;
+    public float HoldDuration {get => holdDuration; set { holdDuration = value;} }
     [SerializeField] private float holdCancelThresholdPixels = 20f;
 
     private TowerUnit towerUnit;

--- a/Bismuth/Assets/Scripts/이수형/BoardSystem/UnitInputRouter.cs
+++ b/Bismuth/Assets/Scripts/이수형/BoardSystem/UnitInputRouter.cs
@@ -13,6 +13,7 @@ public class UnitPointerInputRouter : MonoBehaviour
     [SerializeField] private GameObject unitInfoPanel;
     [SerializeField] private GameObject _combinationScrollView;
 
+    [SerializeField][Range(0.1f, 0.5f)] private float _holdDuration = 0.5f;
 
     private AttackRangeVisualizer _previousRangeVisualizer;
 
@@ -52,6 +53,7 @@ public class UnitPointerInputRouter : MonoBehaviour
 
 
         TowerLongPressDragHandler dragHandler = hit.GetComponent<TowerLongPressDragHandler>();
+        dragHandler.HoldDuration = _holdDuration;
 
         if (dragHandler == null)
             dragHandler = hit.GetComponentInParent<TowerLongPressDragHandler>();

--- a/Bismuth/Assets/Scripts/이수형/Combat/AttackContext.cs
+++ b/Bismuth/Assets/Scripts/이수형/Combat/AttackContext.cs
@@ -1,34 +1,32 @@
 
-// 공격 한 번의 맥락을 담는 구조체.
-// bool 파라미터 나열 대신 이 구조체 하나를 전달한다.
 
 public struct AttackContext
 {
-    // 일반 공격(평타)인지 여부. false면 시너지 추가타 등 스킬 공격이다. 
+
     public bool IsNormalAttack;
 
-    // 전사 시너지 추가타 여부 
+
     public bool IsWarriorBonus;
 
-    // 마법사 시너지 추가 대미지 여부 
+
     public bool IsWizardBonus;
 
-    // 궁수 시너지 강화 공격 여부 
+
     public bool IsArcherBonus;
 
-    // 수인 시너지 추가타 여부 (Step 3에서 사용) 
+
     public bool IsFurryBonus;
 
-    // 애니메이션 배속 배율. 기본=1, 수인 추가타=N 
+
     public float AnimSpeedMultiplier;
 
-    // 기본 일반공격 컨텍스트를 생성한다.
+
     public static AttackContext Normal()
     {
         return new AttackContext { IsNormalAttack = true, AnimSpeedMultiplier = 1f };
     }
 
-    // 시너지 스택 적립 대상인지 판별한다. 일반공격만 적립 대상이다. 
+
     public bool CountsForSynergyStacks => IsNormalAttack && !IsWarriorBonus && !IsFurryBonus;
 
     public override string ToString()
@@ -38,7 +36,7 @@ public struct AttackContext
 }
 
 
-// 추가 공격의 종류를 구분하는 열거형.
+
 
 public enum ExtraAttackType
 {
@@ -47,24 +45,23 @@ public enum ExtraAttackType
 }
 
 
-// 대기 중인 추가 공격 배치 하나를 표현한다.
-// 큐에 넣어 순서대로 처리한다.
+
 
 public struct PendingExtraAttack
 {
-    // 추가 공격 종류 
+
     public ExtraAttackType Type;
 
-    // 이 배치에서 남은 공격 횟수 
+
     public int RemainingCount;
 
-    // 강제 타겟. null이면 센서에서 가장 가까운 적을 사용한다.
+
     public MonsterController ForcedTarget;
 
-    // 애니메이션 배속 배율. 전사=1, 수인=추가타 횟수 
+
     public float AnimSpeedMultiplier;
 
-    // 이 배치가 아직 처리할 공격이 남아있는지 
+
     public bool HasRemaining => RemainingCount > 0;
 
     public override string ToString()

--- a/Bismuth/Assets/Scripts/이수형/Combat/CombatManager.cs
+++ b/Bismuth/Assets/Scripts/이수형/Combat/CombatManager.cs
@@ -58,6 +58,21 @@ public class CombatManager : MonoBehaviour
     private readonly List<MonsterMover> _slowedMonsters = new();
     private bool _isSpiritActive;
 
+    [Header("Orc Synergy")]
+    [SerializeField, Min(0.1f)] private float orcCooldown = 10f;
+    [SerializeField] private bool orcSynergyLog = false;
+
+    private Coroutine _orcRoutine;
+    private readonly List<SpriteColorTint> _orcTintedUnits = new();
+    private bool _isOrcActive;
+    private bool _isOrcBuffActive;
+    private bool _isWaveActive;
+    private float _orcBuffPercent;
+    private static readonly Color OrcBuffTintColor = new Color(1f, 0.5f, 0.5f, 1f);
+
+    public bool IsOrcBuffActive => _isOrcBuffActive;
+    public float OrcBuffPercent => _orcBuffPercent;
+
     private Collider2D[] aoeOverlapResults;
 
     private void Awake()
@@ -91,17 +106,23 @@ public class CombatManager : MonoBehaviour
             synergyManager = gameManager.GetComponent<SynergyManager>();
         if (_battleWaveRunner == null)
             _battleWaveRunner = FindFirstObjectByType<BattleWaveRunner>();
-        if(playerDataManager == null)
+        if (playerDataManager == null)
             playerDataManager = FindFirstObjectByType<PlayerDataManager>();
     }
 
     private void OnEnable()
     {
         if (_battleWaveRunner != null)
+        {
             _battleWaveRunner.WaveStarted += OnWaveStarted;
+            _battleWaveRunner.WaveCleared += OnWaveCleared;
+        }
 
         if (synergyManager != null)
             synergyManager.OnSynergyChanged += HandleSynergyChangedForSpirit;
+
+        if (synergyManager != null)
+            synergyManager.OnSynergyChanged += HandleSynergyChangedForOrc;
     }
 
     private void Start()
@@ -112,7 +133,13 @@ public class CombatManager : MonoBehaviour
     private void OnDisable()
     {
         if (_battleWaveRunner != null)
+        {
             _battleWaveRunner.WaveStarted -= OnWaveStarted;
+            _battleWaveRunner.WaveCleared -= OnWaveCleared;
+        }
+
+        if (synergyManager != null)
+            synergyManager.OnSynergyChanged -= HandleSynergyChangedForOrc;
     }
 
     private void OnValidate()
@@ -496,7 +523,7 @@ public class CombatManager : MonoBehaviour
 
             if (HasSynergyTag(unitStat, (int)SynergyManager.SynergyType.Elf))
             {
-                if(unitStat.ElfWaveKillCount < 10)
+                if (unitStat.ElfWaveKillCount < 10)
                     unitStat.ElfWaveKillCount++;
                 DebugTool.Log(
                     $"엘프 웨이브 킬 적립 | source={sourceName}, elfKill={unitStat.ElfWaveKillCount}",
@@ -526,7 +553,7 @@ public class CombatManager : MonoBehaviour
 
 
         int activeCount = synergyManager.GetSynergyLevel((int)SynergyManager.SynergyType.Human);
-        
+
         Debug.Log(
             $"인간 시너지 레벨 조회 | activeCount={activeCount}"
         );
@@ -906,6 +933,34 @@ public class CombatManager : MonoBehaviour
     private void OnWaveStarted(WaveDataSO waveData)
     {
         ResetAllElfWaveKillCounts();
+
+        _isWaveActive = true;
+
+  
+        if (_isOrcActive && _orcRoutine == null)
+        {
+            _orcRoutine = StartCoroutine(OrcSynergyRoutine());
+
+            if (orcSynergyLog)
+                DebugTool.Log("오크 시너지 버프 사이클 시작 | 웨이브 시작", DebugType.Synergy, this);
+        }
+    }
+
+    private void OnWaveCleared(WaveDataSO waveData)
+    {
+        _isWaveActive = false;
+
+
+        if (_orcRoutine != null)
+        {
+            StopCoroutine(_orcRoutine);
+            _orcRoutine = null;
+        }
+
+        RemoveOrcBuff();
+
+        if (orcSynergyLog)
+            DebugTool.Log("오크 시너지 버프 해제 및 쿨타임 초기화 | 웨이브 클리어", DebugType.Synergy, this);
     }
 
     private void ResetAllElfWaveKillCounts()
@@ -1111,5 +1166,189 @@ public class CombatManager : MonoBehaviour
             return int.MaxValue;
 
         return spiritData.Levels[0].ActiveCount;
+    }
+
+
+
+    private void HandleSynergyChangedForOrc(Dictionary<int, List<int>> synergiesDict)
+    {
+        const int orcId = (int)SynergyManager.SynergyType.Orc;
+
+        bool shouldBeActive = synergiesDict.ContainsKey(orcId)
+                              && synergiesDict[orcId].Count >= GetOrcMinActiveCount();
+
+        if (shouldBeActive && !_isOrcActive)
+        {
+            StartOrcSynergy();
+        }
+        else if (!shouldBeActive && _isOrcActive)
+        {
+            StopOrcSynergy();
+        }
+    }
+
+    private void StartOrcSynergy()
+    {
+        if (_isOrcActive)
+            return;
+
+        _isOrcActive = true;
+
+
+        if (_isWaveActive)
+        {
+            _orcRoutine = StartCoroutine(OrcSynergyRoutine());
+            DebugTool.Log("오크 시너지 활성화 | 버프 사이클 즉시 시작", DebugType.Synergy, this);
+        }
+        else
+        {
+            DebugTool.Log("오크 시너지 활성화 | 정비시간이므로 웨이브 시작 시 발동 예정", DebugType.Synergy, this);
+        }
+    }
+
+    private void StopOrcSynergy()
+    {
+        if (!_isOrcActive)
+            return;
+
+        _isOrcActive = false;
+
+        if (_orcRoutine != null)
+        {
+            StopCoroutine(_orcRoutine);
+            _orcRoutine = null;
+        }
+
+        RemoveOrcBuff();
+
+        DebugTool.Log("오크 시너지 비활성화 | 버프 해제 및 사이클 중단", DebugType.Synergy, this);
+    }
+
+    private IEnumerator OrcSynergyRoutine()
+    {
+        while (_isOrcActive && _isWaveActive)
+        {
+            if (!TryGetOrcEffectValues(out float duration, out float attackPercent))
+            {
+                if (orcSynergyLog)
+                    DebugTool.Log("오크 시너지 효과값 조회 실패 | 다음 쿨다운 대기", DebugType.Synergy, this);
+
+                yield return new WaitForSeconds(orcCooldown);
+                continue;
+            }
+
+
+            ApplyOrcBuff(attackPercent);
+
+            if (orcSynergyLog)
+                DebugTool.Log(
+                    $"오크 시너지 발동 | attackBonus={attackPercent:F1}%, duration={duration:F1}s",
+                    DebugType.Synergy, this);
+
+            yield return new WaitForSeconds(duration);
+
+
+            RemoveOrcBuff();
+
+            if (orcSynergyLog)
+                DebugTool.Log("오크 시너지 버프 해제 | 쿨다운 재시작", DebugType.Synergy, this);
+
+            yield return new WaitForSeconds(orcCooldown);
+
+            if (!_isOrcActive || !_isWaveActive)
+                yield break;
+        }
+    }
+
+    private bool TryGetOrcEffectValues(out float duration, out float attackPercent)
+    {
+        duration = 0f;
+        attackPercent = 0f;
+
+        if (synergySO == null || synergyManager == null)
+            return false;
+
+        const int orcId = (int)SynergyManager.SynergyType.Orc;
+
+        SynergyData orcData = GetSynergyData(orcId);
+        if (orcData == null || orcData.Levels == null || orcData.Levels.Count == 0)
+            return false;
+
+        int activeCount = synergyManager.GetSynergyLevel(orcId);
+
+        SynergyLevelData matchedLevel = null;
+        for (int i = 0; i < orcData.Levels.Count; i++)
+        {
+            SynergyLevelData level = orcData.Levels[i];
+            if (level == null)
+                continue;
+
+            if (activeCount < level.ActiveCount)
+                continue;
+
+            matchedLevel = level;
+        }
+
+        if (matchedLevel == null || matchedLevel.EffectValues == null || matchedLevel.EffectValues.Count == 0)
+            return false;
+
+        attackPercent = matchedLevel.EffectValues[0];
+        duration = 5f;
+        return true;
+    }
+
+    private void ApplyOrcBuff(float attackPercent)
+    {
+        _orcBuffPercent = attackPercent;
+        _isOrcBuffActive = true;
+        _orcTintedUnits.Clear();
+
+        const int orcId = (int)SynergyManager.SynergyType.Orc;
+        UnitStat[] allUnits = FindObjectsByType<UnitStat>(FindObjectsSortMode.None);
+
+        for (int i = 0; i < allUnits.Length; i++)
+        {
+            if (!HasSynergyTag(allUnits[i], orcId))
+                continue;
+
+            SpriteColorTint tint = new SpriteColorTint(allUnits[i].gameObject);
+            tint.Apply(OrcBuffTintColor);
+            _orcTintedUnits.Add(tint);
+        }
+
+        if (orcSynergyLog)
+            DebugTool.Log(
+                $"오크 버프 적용 | percent={attackPercent:F1}%, tintedUnits={_orcTintedUnits.Count}",
+                DebugType.Synergy, this);
+    }
+
+    private void RemoveOrcBuff()
+    {
+        _isOrcBuffActive = false;
+        _orcBuffPercent = 0f;
+
+        for (int i = 0; i < _orcTintedUnits.Count; i++)
+        {
+            _orcTintedUnits[i]?.Remove();
+        }
+
+        _orcTintedUnits.Clear();
+
+        if (orcSynergyLog)
+            DebugTool.Log("오크 버프 해제 | 틴트 제거 완료", DebugType.Synergy, this);
+    }
+
+    private int GetOrcMinActiveCount()
+    {
+        if (synergySO == null)
+            return int.MaxValue;
+
+        const int orcId = (int)SynergyManager.SynergyType.Orc;
+        SynergyData orcData = GetSynergyData(orcId);
+
+        if (orcData == null || orcData.Levels == null || orcData.Levels.Count == 0)
+            return int.MaxValue;
+
+        return orcData.Levels[0].ActiveCount;
     }
 }

--- a/Bismuth/Assets/Scripts/이수형/Combat/CombatManager.cs
+++ b/Bismuth/Assets/Scripts/이수형/Combat/CombatManager.cs
@@ -73,21 +73,6 @@ public class CombatManager : MonoBehaviour
     public bool IsOrcBuffActive => _isOrcBuffActive;
     public float OrcBuffPercent => _orcBuffPercent;
 
-    [Header("Orc Synergy")]
-    [SerializeField, Min(0.1f)] private float orcCooldown = 10f;
-    [SerializeField] private bool orcSynergyLog = false;
-
-    private Coroutine _orcRoutine;
-    private readonly List<SpriteColorTint> _orcTintedUnits = new();
-    private bool _isOrcActive;
-    private bool _isOrcBuffActive;
-    private bool _isWaveActive;
-    private float _orcBuffPercent;
-    private static readonly Color OrcBuffTintColor = new Color(1f, 0.5f, 0.5f, 1f);
-
-    public bool IsOrcBuffActive => _isOrcBuffActive;
-    public float OrcBuffPercent => _orcBuffPercent;
-
     private Collider2D[] aoeOverlapResults;
 
     private void Awake()
@@ -122,7 +107,6 @@ public class CombatManager : MonoBehaviour
         if (_battleWaveRunner == null)
             _battleWaveRunner = FindFirstObjectByType<BattleWaveRunner>();
         if (playerDataManager == null)
-        if (playerDataManager == null)
             playerDataManager = FindFirstObjectByType<PlayerDataManager>();
     }
 
@@ -130,18 +114,12 @@ public class CombatManager : MonoBehaviour
     {
         if (_battleWaveRunner != null)
         {
-        {
             _battleWaveRunner.WaveStarted += OnWaveStarted;
-            _battleWaveRunner.WaveCleared += OnWaveCleared;
-        }
             _battleWaveRunner.WaveCleared += OnWaveCleared;
         }
 
         if (synergyManager != null)
             synergyManager.OnSynergyChanged += HandleSynergyChangedForSpirit;
-
-        if (synergyManager != null)
-            synergyManager.OnSynergyChanged += HandleSynergyChangedForOrc;
 
         if (synergyManager != null)
             synergyManager.OnSynergyChanged += HandleSynergyChangedForOrc;
@@ -156,13 +134,7 @@ public class CombatManager : MonoBehaviour
     {
         if (_battleWaveRunner != null)
         {
-        {
             _battleWaveRunner.WaveStarted -= OnWaveStarted;
-            _battleWaveRunner.WaveCleared -= OnWaveCleared;
-        }
-
-        if (synergyManager != null)
-            synergyManager.OnSynergyChanged -= HandleSynergyChangedForOrc;
             _battleWaveRunner.WaveCleared -= OnWaveCleared;
         }
 
@@ -552,7 +524,6 @@ public class CombatManager : MonoBehaviour
             if (HasSynergyTag(unitStat, (int)SynergyManager.SynergyType.Elf))
             {
                 if (unitStat.ElfWaveKillCount < 10)
-                if (unitStat.ElfWaveKillCount < 10)
                     unitStat.ElfWaveKillCount++;
                 DebugTool.Log(
                     $"엘프 웨이브 킬 적립 | source={sourceName}, elfKill={unitStat.ElfWaveKillCount}",
@@ -582,7 +553,6 @@ public class CombatManager : MonoBehaviour
 
 
         int activeCount = synergyManager.GetSynergyLevel((int)SynergyManager.SynergyType.Human);
-
 
         Debug.Log(
             $"인간 시너지 레벨 조회 | activeCount={activeCount}"
@@ -966,7 +936,7 @@ public class CombatManager : MonoBehaviour
 
         _isWaveActive = true;
 
-  
+        // 오크 시너지가 활성 상태인데 코루틴이 없으면 시작
         if (_isOrcActive && _orcRoutine == null)
         {
             _orcRoutine = StartCoroutine(OrcSynergyRoutine());
@@ -980,7 +950,7 @@ public class CombatManager : MonoBehaviour
     {
         _isWaveActive = false;
 
-
+        // 오크 버프 즉시 해제 + 코루틴 정지 + 쿨타임 초기화
         if (_orcRoutine != null)
         {
             StopCoroutine(_orcRoutine);
@@ -1224,7 +1194,7 @@ public class CombatManager : MonoBehaviour
 
         _isOrcActive = true;
 
-
+        // 웨이브 진행 중일 때만 코루틴 즉시 시작, 정비시간이면 웨이브 시작 시 시작됨
         if (_isWaveActive)
         {
             _orcRoutine = StartCoroutine(OrcSynergyRoutine());

--- a/Bismuth/Assets/Scripts/이수형/Combat/CombatManager.cs
+++ b/Bismuth/Assets/Scripts/이수형/Combat/CombatManager.cs
@@ -58,6 +58,21 @@ public class CombatManager : MonoBehaviour
     private readonly List<MonsterMover> _slowedMonsters = new();
     private bool _isSpiritActive;
 
+    [Header("Orc Synergy")]
+    [SerializeField, Min(0.1f)] private float orcCooldown = 10f;
+    [SerializeField] private bool orcSynergyLog = false;
+
+    private Coroutine _orcRoutine;
+    private readonly List<SpriteColorTint> _orcTintedUnits = new();
+    private bool _isOrcActive;
+    private bool _isOrcBuffActive;
+    private bool _isWaveActive;
+    private float _orcBuffPercent;
+    private static readonly Color OrcBuffTintColor = new Color(1f, 0.5f, 0.5f, 1f);
+
+    public bool IsOrcBuffActive => _isOrcBuffActive;
+    public float OrcBuffPercent => _orcBuffPercent;
+
     private Collider2D[] aoeOverlapResults;
 
     private void Awake()
@@ -91,17 +106,23 @@ public class CombatManager : MonoBehaviour
             synergyManager = gameManager.GetComponent<SynergyManager>();
         if (_battleWaveRunner == null)
             _battleWaveRunner = FindFirstObjectByType<BattleWaveRunner>();
-        if(playerDataManager == null)
+        if (playerDataManager == null)
             playerDataManager = FindFirstObjectByType<PlayerDataManager>();
     }
 
     private void OnEnable()
     {
         if (_battleWaveRunner != null)
+        {
             _battleWaveRunner.WaveStarted += OnWaveStarted;
+            _battleWaveRunner.WaveCleared += OnWaveCleared;
+        }
 
         if (synergyManager != null)
             synergyManager.OnSynergyChanged += HandleSynergyChangedForSpirit;
+
+        if (synergyManager != null)
+            synergyManager.OnSynergyChanged += HandleSynergyChangedForOrc;
     }
 
     private void Start()
@@ -112,7 +133,13 @@ public class CombatManager : MonoBehaviour
     private void OnDisable()
     {
         if (_battleWaveRunner != null)
+        {
             _battleWaveRunner.WaveStarted -= OnWaveStarted;
+            _battleWaveRunner.WaveCleared -= OnWaveCleared;
+        }
+
+        if (synergyManager != null)
+            synergyManager.OnSynergyChanged -= HandleSynergyChangedForOrc;
     }
 
     private void OnValidate()
@@ -496,7 +523,7 @@ public class CombatManager : MonoBehaviour
 
             if (HasSynergyTag(unitStat, (int)SynergyManager.SynergyType.Elf))
             {
-                if(unitStat.ElfWaveKillCount < 10)
+                if (unitStat.ElfWaveKillCount < 10)
                     unitStat.ElfWaveKillCount++;
                 DebugTool.Log(
                     $"엘프 웨이브 킬 적립 | source={sourceName}, elfKill={unitStat.ElfWaveKillCount}",
@@ -526,7 +553,7 @@ public class CombatManager : MonoBehaviour
 
 
         int activeCount = synergyManager.GetSynergyLevel((int)SynergyManager.SynergyType.Human);
-        
+
         Debug.Log(
             $"인간 시너지 레벨 조회 | activeCount={activeCount}"
         );
@@ -906,6 +933,34 @@ public class CombatManager : MonoBehaviour
     private void OnWaveStarted(WaveDataSO waveData)
     {
         ResetAllElfWaveKillCounts();
+
+        _isWaveActive = true;
+
+        // 오크 시너지가 활성 상태인데 코루틴이 없으면 시작
+        if (_isOrcActive && _orcRoutine == null)
+        {
+            _orcRoutine = StartCoroutine(OrcSynergyRoutine());
+
+            if (orcSynergyLog)
+                DebugTool.Log("오크 시너지 버프 사이클 시작 | 웨이브 시작", DebugType.Synergy, this);
+        }
+    }
+
+    private void OnWaveCleared(WaveDataSO waveData)
+    {
+        _isWaveActive = false;
+
+        // 오크 버프 즉시 해제 + 코루틴 정지 + 쿨타임 초기화
+        if (_orcRoutine != null)
+        {
+            StopCoroutine(_orcRoutine);
+            _orcRoutine = null;
+        }
+
+        RemoveOrcBuff();
+
+        if (orcSynergyLog)
+            DebugTool.Log("오크 시너지 버프 해제 및 쿨타임 초기화 | 웨이브 클리어", DebugType.Synergy, this);
     }
 
     private void ResetAllElfWaveKillCounts()
@@ -1111,5 +1166,189 @@ public class CombatManager : MonoBehaviour
             return int.MaxValue;
 
         return spiritData.Levels[0].ActiveCount;
+    }
+
+
+
+    private void HandleSynergyChangedForOrc(Dictionary<int, List<int>> synergiesDict)
+    {
+        const int orcId = (int)SynergyManager.SynergyType.Orc;
+
+        bool shouldBeActive = synergiesDict.ContainsKey(orcId)
+                              && synergiesDict[orcId].Count >= GetOrcMinActiveCount();
+
+        if (shouldBeActive && !_isOrcActive)
+        {
+            StartOrcSynergy();
+        }
+        else if (!shouldBeActive && _isOrcActive)
+        {
+            StopOrcSynergy();
+        }
+    }
+
+    private void StartOrcSynergy()
+    {
+        if (_isOrcActive)
+            return;
+
+        _isOrcActive = true;
+
+        // 웨이브 진행 중일 때만 코루틴 즉시 시작, 정비시간이면 웨이브 시작 시 시작됨
+        if (_isWaveActive)
+        {
+            _orcRoutine = StartCoroutine(OrcSynergyRoutine());
+            DebugTool.Log("오크 시너지 활성화 | 버프 사이클 즉시 시작", DebugType.Synergy, this);
+        }
+        else
+        {
+            DebugTool.Log("오크 시너지 활성화 | 정비시간이므로 웨이브 시작 시 발동 예정", DebugType.Synergy, this);
+        }
+    }
+
+    private void StopOrcSynergy()
+    {
+        if (!_isOrcActive)
+            return;
+
+        _isOrcActive = false;
+
+        if (_orcRoutine != null)
+        {
+            StopCoroutine(_orcRoutine);
+            _orcRoutine = null;
+        }
+
+        RemoveOrcBuff();
+
+        DebugTool.Log("오크 시너지 비활성화 | 버프 해제 및 사이클 중단", DebugType.Synergy, this);
+    }
+
+    private IEnumerator OrcSynergyRoutine()
+    {
+        while (_isOrcActive && _isWaveActive)
+        {
+            if (!TryGetOrcEffectValues(out float duration, out float attackPercent))
+            {
+                if (orcSynergyLog)
+                    DebugTool.Log("오크 시너지 효과값 조회 실패 | 다음 쿨다운 대기", DebugType.Synergy, this);
+
+                yield return new WaitForSeconds(orcCooldown);
+                continue;
+            }
+
+
+            ApplyOrcBuff(attackPercent);
+
+            if (orcSynergyLog)
+                DebugTool.Log(
+                    $"오크 시너지 발동 | attackBonus={attackPercent:F1}%, duration={duration:F1}s",
+                    DebugType.Synergy, this);
+
+            yield return new WaitForSeconds(duration);
+
+
+            RemoveOrcBuff();
+
+            if (orcSynergyLog)
+                DebugTool.Log("오크 시너지 버프 해제 | 쿨다운 재시작", DebugType.Synergy, this);
+
+            yield return new WaitForSeconds(orcCooldown);
+
+            if (!_isOrcActive || !_isWaveActive)
+                yield break;
+        }
+    }
+
+    private bool TryGetOrcEffectValues(out float duration, out float attackPercent)
+    {
+        duration = 0f;
+        attackPercent = 0f;
+
+        if (synergySO == null || synergyManager == null)
+            return false;
+
+        const int orcId = (int)SynergyManager.SynergyType.Orc;
+
+        SynergyData orcData = GetSynergyData(orcId);
+        if (orcData == null || orcData.Levels == null || orcData.Levels.Count == 0)
+            return false;
+
+        int activeCount = synergyManager.GetSynergyLevel(orcId);
+
+        SynergyLevelData matchedLevel = null;
+        for (int i = 0; i < orcData.Levels.Count; i++)
+        {
+            SynergyLevelData level = orcData.Levels[i];
+            if (level == null)
+                continue;
+
+            if (activeCount < level.ActiveCount)
+                continue;
+
+            matchedLevel = level;
+        }
+
+        if (matchedLevel == null || matchedLevel.EffectValues == null || matchedLevel.EffectValues.Count == 0)
+            return false;
+
+        attackPercent = matchedLevel.EffectValues[0];
+        duration = 5f;
+        return true;
+    }
+
+    private void ApplyOrcBuff(float attackPercent)
+    {
+        _orcBuffPercent = attackPercent;
+        _isOrcBuffActive = true;
+        _orcTintedUnits.Clear();
+
+        const int orcId = (int)SynergyManager.SynergyType.Orc;
+        UnitStat[] allUnits = FindObjectsByType<UnitStat>(FindObjectsSortMode.None);
+
+        for (int i = 0; i < allUnits.Length; i++)
+        {
+            if (!HasSynergyTag(allUnits[i], orcId))
+                continue;
+
+            SpriteColorTint tint = new SpriteColorTint(allUnits[i].gameObject);
+            tint.Apply(OrcBuffTintColor);
+            _orcTintedUnits.Add(tint);
+        }
+
+        if (orcSynergyLog)
+            DebugTool.Log(
+                $"오크 버프 적용 | percent={attackPercent:F1}%, tintedUnits={_orcTintedUnits.Count}",
+                DebugType.Synergy, this);
+    }
+
+    private void RemoveOrcBuff()
+    {
+        _isOrcBuffActive = false;
+        _orcBuffPercent = 0f;
+
+        for (int i = 0; i < _orcTintedUnits.Count; i++)
+        {
+            _orcTintedUnits[i]?.Remove();
+        }
+
+        _orcTintedUnits.Clear();
+
+        if (orcSynergyLog)
+            DebugTool.Log("오크 버프 해제 | 틴트 제거 완료", DebugType.Synergy, this);
+    }
+
+    private int GetOrcMinActiveCount()
+    {
+        if (synergySO == null)
+            return int.MaxValue;
+
+        const int orcId = (int)SynergyManager.SynergyType.Orc;
+        SynergyData orcData = GetSynergyData(orcId);
+
+        if (orcData == null || orcData.Levels == null || orcData.Levels.Count == 0)
+            return int.MaxValue;
+
+        return orcData.Levels[0].ActiveCount;
     }
 }

--- a/Bismuth/Assets/Scripts/이수형/Combat/DamageCalculator.cs
+++ b/Bismuth/Assets/Scripts/이수형/Combat/DamageCalculator.cs
@@ -7,6 +7,7 @@ public class DamageCalculator : MonoBehaviour
     private const int ArcherSynergyId = (int)SynergyManager.SynergyType.Archer;
     private const int FighterSynergyId = (int)SynergyManager.SynergyType.Fighter;
     private const int ElfSynergyId = (int)SynergyManager.SynergyType.Elf;
+    private const int OrcSynergyId = (int)SynergyManager.SynergyType.Orc;
 
     [Header("Synergy")]
     [SerializeField] private SynergySO synergySO;
@@ -28,9 +29,10 @@ public class DamageCalculator : MonoBehaviour
 
     public int CalculateNormalDamage(UnitStat attackerStat, float damageDealt, float defense, float crit)
     {
-        float warriorMultiplier = 1 + GetWarriorAttackMultiplier(attackerStat) * 0.01f;
-        float elfMultiplier = 1 + GetElfAttackMultiplier(attackerStat) * 0.01f;
-        float calculatedDamage = damageDealt * warriorMultiplier * elfMultiplier * (1f + crit) * (100f / (defense + 100f));
+        float warriorMultiplier = GetWarriorAttackMultiplier(attackerStat) * 0.01f;
+        float elfMultiplier = GetElfAttackMultiplier(attackerStat) * 0.01f;
+        float orcMultiplier = GetOrcAttackMultiplier(attackerStat) * 0.01f;
+        float calculatedDamage = damageDealt * (warriorMultiplier + elfMultiplier + orcMultiplier + 1f) * (1f + crit) * (100f / (defense + 100f));
 
         if (Random.value < calculatedDamage - (int)calculatedDamage)
             return (int)calculatedDamage + 1;
@@ -262,6 +264,28 @@ public class DamageCalculator : MonoBehaviour
         }
 
         return totalBonus;
+    }
+
+    private float GetOrcAttackMultiplier(UnitStat attackerStat)
+    {
+        if (!HasSynergyTag(attackerStat, OrcSynergyId))
+            return 0f;
+
+        if (CombatManager.Instance == null || !CombatManager.Instance.IsOrcBuffActive)
+            return 0f;
+
+        float bonus = CombatManager.Instance.OrcBuffPercent;
+
+        if (synergyLog && bonus > 0f)
+        {
+            DebugTool.Log(
+                $"오크 공격력 배율 적용 | unit={attackerStat.Name}, bonus={bonus:F2}",
+                DebugType.Synergy,
+                this
+            );
+        }
+
+        return bonus;
     }
 
     private void TryResolveSynergyManager()

--- a/Bismuth/Assets/Scripts/이수형/Monster/SpriteColorTint.cs
+++ b/Bismuth/Assets/Scripts/이수형/Monster/SpriteColorTint.cs
@@ -1,0 +1,73 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+
+public class SpriteColorTint
+{
+    private readonly SpriteRenderer[] _renderers;
+    private readonly Dictionary<SpriteRenderer, Color> _originalColors = new();
+    private readonly string _ownerName;
+    private bool _isTinted;
+
+    public bool IsTinted => _isTinted;
+
+
+    public SpriteColorTint(GameObject target)
+    {
+        if (target == null)
+        {
+            _renderers = System.Array.Empty<SpriteRenderer>();
+            _ownerName = "None";
+            DebugTool.Warnning("SpriteColorTint 초기화 실패 : target이 null입니다.", DebugType.Unit);
+            return;
+        }
+
+        _ownerName = target.name;
+        _renderers = target.GetComponentsInChildren<SpriteRenderer>(true);
+
+        DebugTool.Log(
+            $"SpriteColorTint 초기화 | owner={_ownerName}, rendererCount={_renderers.Length}",
+            DebugType.Unit);
+    }
+
+
+    public void Apply(Color tintColor)
+    {
+        _originalColors.Clear();
+
+        for (int i = 0; i < _renderers.Length; i++)
+        {
+            if (_renderers[i] == null)
+                continue;
+
+            _originalColors[_renderers[i]] = _renderers[i].color;
+            _renderers[i].color *= tintColor;
+        }
+
+        _isTinted = true;
+
+        DebugTool.Log(
+            $"틴트 적용 | owner={_ownerName}, color={tintColor}",
+            DebugType.Unit);
+    }
+
+
+    public void Remove()
+    {
+        for (int i = 0; i < _renderers.Length; i++)
+        {
+            if (_renderers[i] == null)
+                continue;
+
+            if (_originalColors.TryGetValue(_renderers[i], out Color original))
+                _renderers[i].color = original;
+        }
+
+        _originalColors.Clear();
+        _isTinted = false;
+
+        DebugTool.Log(
+            $"틴트 해제 | owner={_ownerName}",
+            DebugType.Unit);
+    }
+}

--- a/Bismuth/Assets/Scripts/이수형/Monster/SpriteColorTint.cs
+++ b/Bismuth/Assets/Scripts/이수형/Monster/SpriteColorTint.cs
@@ -1,0 +1,84 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// 특정 GameObject 하위의 모든 SpriteRenderer에 색상 틴트를 적용/해제하는 유틸 클래스.
+/// 틴트 적용 시 원본 색상을 저장하고 틴트 색상을 곱하며, 해제 시 원본으로 복원한다.
+/// </summary>
+public class SpriteColorTint
+{
+    private readonly SpriteRenderer[] _renderers;
+    private readonly Dictionary<SpriteRenderer, Color> _originalColors = new();
+    private readonly string _ownerName;
+    private bool _isTinted;
+
+    public bool IsTinted => _isTinted;
+
+    /// <summary>
+    /// 대상 오브젝트 하위의 모든 SpriteRenderer를 수집하여 초기화한다.
+    /// </summary>
+    /// <param name="target">틴트를 적용할 루트 오브젝트</param>
+    public SpriteColorTint(GameObject target)
+    {
+        if (target == null)
+        {
+            _renderers = System.Array.Empty<SpriteRenderer>();
+            _ownerName = "None";
+            DebugTool.Warnning("SpriteColorTint 초기화 실패 : target이 null입니다.", DebugType.Unit);
+            return;
+        }
+
+        _ownerName = target.name;
+        _renderers = target.GetComponentsInChildren<SpriteRenderer>(true);
+
+        DebugTool.Log(
+            $"SpriteColorTint 초기화 | owner={_ownerName}, rendererCount={_renderers.Length}",
+            DebugType.Unit);
+    }
+
+    /// <summary>
+    /// 틴트 색상을 적용한다. 원본 색상을 저장한 뒤 틴트를 곱한다.
+    /// </summary>
+    /// <param name="tintColor">적용할 틴트 색상</param>
+    public void Apply(Color tintColor)
+    {
+        _originalColors.Clear();
+
+        for (int i = 0; i < _renderers.Length; i++)
+        {
+            if (_renderers[i] == null)
+                continue;
+
+            _originalColors[_renderers[i]] = _renderers[i].color;
+            _renderers[i].color *= tintColor;
+        }
+
+        _isTinted = true;
+
+        DebugTool.Log(
+            $"틴트 적용 | owner={_ownerName}, color={tintColor}",
+            DebugType.Unit);
+    }
+
+    /// <summary>
+    /// 틴트를 해제하고 저장해둔 원본 색상으로 복원한다.
+    /// </summary>
+    public void Remove()
+    {
+        for (int i = 0; i < _renderers.Length; i++)
+        {
+            if (_renderers[i] == null)
+                continue;
+
+            if (_originalColors.TryGetValue(_renderers[i], out Color original))
+                _renderers[i].color = original;
+        }
+
+        _originalColors.Clear();
+        _isTinted = false;
+
+        DebugTool.Log(
+            $"틴트 해제 | owner={_ownerName}",
+            DebugType.Unit);
+    }
+}

--- a/Bismuth/Assets/Scripts/이수형/Monster/SpriteColorTint.cs.meta
+++ b/Bismuth/Assets/Scripts/이수형/Monster/SpriteColorTint.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 616a3fb8f2856fc4fb53f0c4a8fee6fa

--- a/Bismuth/Assets/Scripts/조경민/ControlPanelUI.cs
+++ b/Bismuth/Assets/Scripts/조경민/ControlPanelUI.cs
@@ -61,6 +61,8 @@ public class ControlPanelUI : MonoBehaviour
         _playerAction.Enable();
 
         _playerAction.UI.Combination.performed += OnClickCombination;
+        _playerData.OnLevelChanged += RefreshLevel;
+        _playerData.OnLevelChanged += RefreshUpgradeGold;
     }
 
     private void Start()
@@ -78,6 +80,8 @@ public class ControlPanelUI : MonoBehaviour
         _playerAction.Disable();
         
         LocalizationManager.Instance.OnLocalizationLoaded -= RefreshText;
+        _playerData.OnLevelChanged -= RefreshLevel;
+        _playerData.OnLevelChanged -= RefreshUpgradeGold;
     }
 
     private void RefreshText()

--- a/Bismuth/Assets/Scripts/조경민/GameViewPanelUI.cs
+++ b/Bismuth/Assets/Scripts/조경민/GameViewPanelUI.cs
@@ -1,58 +1,55 @@
 using TMPro;
 using UnityEngine;
+using UnityEngine.InputSystem;
 using UnityEngine.UI;
 
 public class GameViewPanelUI : MonoBehaviour
 {
-    [Header("━━━━ 참조 ━━━━")]
-    [SerializeField] private BattleWaveRunner _battleWaveRunner;
+    [Header("━━━━ 참조 ━━━━")] [SerializeField]
+    private BattleWaveRunner _battleWaveRunner;
 
-    [Header("━━━━ 정비 UI ━━━━")]
-    [SerializeField] private GameObject _skipButton;
+    [Header("━━━━ 정비 UI ━━━━")] [SerializeField]
+    private GameObject _skipButton;
 
-    [Header("━━━━ 전투 UI ━━━━")]
-    [SerializeField] private GameObject _fastButtonObject;
+    [Header("━━━━ 전투 UI ━━━━")] [SerializeField]
+    private GameObject _fastButtonObject;
+
     [SerializeField] private GameObject _pauseButtonObject;
 
-    [Header("━━━━ 텍스트 ━━━━")]
-    [Tooltip("웨이브(Wave 00 (00/00)")]
-    [SerializeField] private TMP_Text _waveText;
-    [Tooltip("정비 시간 00:00")]
-    [SerializeField] private TMP_Text _preparationTimeText;
-    [Tooltip("배속")]
-    [SerializeField] private TMP_Text _extraSpeedText;
+    [Header("━━━━ 텍스트 ━━━━")] [Tooltip("웨이브(Wave 00 (00/00)")] [SerializeField]
+    private TMP_Text _waveText;
 
-    [Header("━━━━ 버튼(이미지) ━━━━")]
-    [Tooltip("배속 버튼")]
-    [SerializeField] private Image _fastButtonImage;
-    [Tooltip("일시정지 버튼")]
-    [SerializeField] private Image _pauseButtonImage;
+    [Tooltip("정비 시간 00:00")] [SerializeField]
+    private TMP_Text _preparationTimeText;
 
-    [Header("━━━━ 패널 ━━━━")]
-    [Tooltip("Esc 팝업")]
-    [SerializeField] private GameObject _pausePopup;
-    [Tooltip("일시정지 패널")]
-    [SerializeField] private GameObject _pausePanel;
+    [Tooltip("배속")] [SerializeField] private TMP_Text _extraSpeedText;
 
-    [Header("━━━━ 설정 ━━━━")]
-    [Tooltip("배속할 속도")]
-    [SerializeField] private float[] _fastSpeed = new float[4] { 1f, 2f, 3f, 4f };
-    [Tooltip("현재 속도")]
-    [SerializeField] private float currentSpeed = 1f;
-    [Tooltip("일시정지 이미지")]
-    [SerializeField] private Sprite _pauseSprite;
-    [Tooltip("재생 이미지")]
-    [SerializeField] private Sprite _playSprite;
-    [Tooltip("일반 배속 이미지")]
-    [SerializeField] private Sprite _baseSpeedSprite;
-    [Tooltip("가속 이미지")]
-    [SerializeField] private Sprite _extraSpeedSprite;
+    [Header("━━━━ 버튼(이미지) ━━━━")] [Tooltip("배속 버튼")] [SerializeField]
+    private Image _fastButtonImage;
 
-    [Header("━━━━ 게임 종료 ━━━━")]
-    [Tooltip("게임 클리어")]
-    [SerializeField] private GameclearPopupUI _gameclearPopupUI;
-    [Tooltip("게임 오버")]
-    [SerializeField] private GameoverPopupUI _gameoverPopupUI;
+    [Tooltip("일시정지 버튼")] [SerializeField] private Image _pauseButtonImage;
+
+    [Header("━━━━ 패널 ━━━━")] [Tooltip("Esc 팝업")] [SerializeField]
+    private GameObject _pausePopup;
+
+    [Tooltip("일시정지 패널")] [SerializeField] private GameObject _pausePanel;
+
+    [Header("━━━━ 설정 ━━━━")] [Tooltip("배속할 속도")] [SerializeField]
+    private float[] _fastSpeed = new float[4] { 1f, 2f, 3f, 4f };
+
+    [Tooltip("현재 속도")] [SerializeField] private float currentSpeed = 1f;
+    [Tooltip("일시정지 이미지")] [SerializeField] private Sprite _pauseSprite;
+    [Tooltip("재생 이미지")] [SerializeField] private Sprite _playSprite;
+
+    [Tooltip("일반 배속 이미지")] [SerializeField]
+    private Sprite _baseSpeedSprite;
+
+    [Tooltip("가속 이미지")] [SerializeField] private Sprite _extraSpeedSprite;
+
+    [Header("━━━━ 게임 종료 ━━━━")] [Tooltip("게임 클리어")] [SerializeField]
+    private GameclearPopupUI _gameclearPopupUI;
+
+    [Tooltip("게임 오버")] [SerializeField] private GameoverPopupUI _gameoverPopupUI;
 
     private bool _isPausePanelOpened => _pausePanel.activeSelf;
     private bool _isFast;
@@ -61,8 +58,12 @@ public class GameViewPanelUI : MonoBehaviour
     private int _currentRemainingCount;
     private int _currentTotalCount;
 
+    private PlayerAction _playerAction;
+
     private void Awake()
     {
+        _playerAction = new PlayerAction();
+        
         _originalColor = _fastButtonImage.color;
     }
 
@@ -77,13 +78,14 @@ public class GameViewPanelUI : MonoBehaviour
         _battleWaveRunner.IntermissionEnded += IntermissionEnded;
         _battleWaveRunner.BattleCompleted += BattleCompleted;
         _battleWaveRunner.BattleFailed += BattleFailed;
+
+        _playerAction.Enable();
+        _playerAction.UI.Pause.performed += OnClickPause;
     }
 
     private void Start()
     {
         RefreshWaveText();
-        // SetBattleUIActive(true);
-        // SetPreparationUIActive(false);
     }
 
     private void OnDisable()
@@ -97,6 +99,10 @@ public class GameViewPanelUI : MonoBehaviour
         _battleWaveRunner.IntermissionEnded -= IntermissionEnded;
         _battleWaveRunner.BattleCompleted -= BattleCompleted;
         _battleWaveRunner.BattleFailed -= BattleFailed;
+        
+        _playerAction.UI.Pause.performed -= OnClickPause;
+        
+        _playerAction.Disable();
     }
 
     // Esc 버튼
@@ -112,27 +118,36 @@ public class GameViewPanelUI : MonoBehaviour
     {
         switch (currentSpeed)
         {
-            case 1f :
+            case 1f:
                 currentSpeed = _fastSpeed[1];
                 _isFast = true;
                 break;
-            case 2f :
+            case 2f:
                 currentSpeed = _fastSpeed[2];
                 break;
-            case 3f :
+            case 3f:
                 currentSpeed = _fastSpeed[3];
                 break;
-            case 4f :
+            case 4f:
                 currentSpeed = _fastSpeed[0];
                 _isFast = false;
                 break;
         }
+
         UpdateFastButton();
         SFXController.Instance.OnClickMenu();
         TimeScaleController.Instance.ChangeSpeed(currentSpeed);
     }
 
-    // 일시정지 버튼
+    public void OnClickPause(InputAction.CallbackContext ctx)
+    {
+        if (ctx.performed)
+        {
+            OnClickPause();
+        }
+    }
+
+// 일시정지 버튼
     public void OnClickPause()
     {
         _pausePanel.SetActive(!_isPausePanelOpened);

--- a/Bismuth/Assets/Scripts/조경민/GameViewPanelUI.cs
+++ b/Bismuth/Assets/Scripts/조경민/GameViewPanelUI.cs
@@ -53,7 +53,6 @@ public class GameViewPanelUI : MonoBehaviour
 
     private bool _isPausePanelOpened => _pausePanel.activeSelf;
     private bool _isFast;
-    private Color _originalColor;
     private int _currentWaveNumber;
     private int _currentRemainingCount;
     private int _currentTotalCount;
@@ -63,8 +62,6 @@ public class GameViewPanelUI : MonoBehaviour
     private void Awake()
     {
         _playerAction = new PlayerAction();
-        
-        _originalColor = _fastButtonImage.color;
     }
 
     private void OnEnable()

--- a/Bismuth/Assets/Scripts/조경민/GameViewPanelUI.cs
+++ b/Bismuth/Assets/Scripts/조경민/GameViewPanelUI.cs
@@ -141,7 +141,7 @@ public class GameViewPanelUI : MonoBehaviour
 
     public void OnClickPause(InputAction.CallbackContext ctx)
     {
-        if (ctx.performed)
+        if (ctx.performed && !_battleWaveRunner.IsIntermissionActive)
         {
             OnClickPause();
         }

--- a/Bismuth/Assets/Scripts/조경민/PauseInputHandler.cs
+++ b/Bismuth/Assets/Scripts/조경민/PauseInputHandler.cs
@@ -27,13 +27,11 @@ public class PauseInputHandler : MonoBehaviour
         Input.Enable();
 
         Input.UI.Settings.performed += OnEsc;
-        Input.UI.Pause.performed += TogglePausePopup;
     }
 
     private void OnDisable()
     {
         Input.UI.Settings.performed -= OnEsc;
-        Input.UI.Pause.performed -= TogglePausePopup;
         Input.Disable();
     }
 

--- a/Bismuth/Assets/Scripts/조경민/SummonChanceUI.cs
+++ b/Bismuth/Assets/Scripts/조경민/SummonChanceUI.cs
@@ -1,0 +1,71 @@
+using TMPro;
+using UnityEngine;
+using UnityEngine.EventSystems;
+
+public class SummonChanceUI : MonoBehaviour, IPointerEnterHandler, IPointerExitHandler
+{
+    [Tooltip("확률 툴팁 패널")]
+    [SerializeField] private GameObject _summonChanceTooltip;
+    [Tooltip("확률 텍스트")]
+    [SerializeField] private TMP_Text _summonChanceText;
+    [SerializeField] private SummonChanceSO _summonChanceSO;
+
+    private PlayerDataManager _playerData;
+    private string _tierText;
+
+    private void Awake()
+    {
+        if (_playerData == null)
+        {
+            _playerData = FindAnyObjectByType<PlayerDataManager>();
+        }
+    }
+
+    private void OnEnable()
+    {
+        LocalizationManager.Instance.OnLocalizationLoaded += RefreshText;
+        RefreshText();
+        _playerData.OnLevelChanged += RefreshChanceText;
+    }
+
+    private void OnDisable()
+    {
+        LocalizationManager.Instance.OnLocalizationLoaded -= RefreshText;
+        _playerData.OnLevelChanged -= RefreshChanceText;
+    }
+
+    private void RefreshText()
+    {
+        _tierText = LocalizationManager.Instance.Get("TIER");
+    }
+
+    private SummonChanceData GetChanceData(int level)
+    {
+        foreach (SummonChanceData data in _summonChanceSO.Rows)
+        {
+            if (data != null && data.EnhancementLevel == level) return data;
+        }
+
+        return null;
+    }
+
+    public void RefreshChanceText()
+    {
+        SummonChanceData data = GetChanceData(_playerData.Level);
+        _summonChanceText.text = $"1{_tierText} {data.Tier1}%\n" +
+                                 $"2{_tierText} {data.Tier2}%\n" +
+                                 $"3{_tierText} {data.Tier3}%\n" +
+                                 $"4{_tierText} {data.Tier4}%";
+    }
+
+    public void OnPointerEnter(PointerEventData eventData)
+    {
+        RefreshChanceText();
+        _summonChanceTooltip.SetActive(true);
+    }
+
+    public void OnPointerExit(PointerEventData eventData)
+    {
+        _summonChanceTooltip.SetActive(false);
+    }
+}

--- a/Bismuth/Assets/Scripts/조경민/SummonChanceUI.cs
+++ b/Bismuth/Assets/Scripts/조경민/SummonChanceUI.cs
@@ -21,9 +21,9 @@ public class SummonChanceUI : MonoBehaviour, IPointerEnterHandler, IPointerExitH
         }
     }
 
-    private void OnEnable()
+    private void Start()
     {
-        LocalizationManager.Instance.OnLocalizationLoaded += RefreshText;
+            LocalizationManager.Instance.OnLocalizationLoaded += RefreshText;
         RefreshText();
         _playerData.OnLevelChanged += RefreshChanceText;
     }

--- a/Bismuth/Assets/Scripts/조경민/SummonChanceUI.cs.meta
+++ b/Bismuth/Assets/Scripts/조경민/SummonChanceUI.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 44ba123f4320b5240b3abea3ffb9d4af

--- a/Bismuth/Assets/Scripts/조경민/TitleSceneUI.cs
+++ b/Bismuth/Assets/Scripts/조경민/TitleSceneUI.cs
@@ -21,11 +21,26 @@ public class TitleSceneUI : MonoBehaviour
     [Header("━━━━ 이미지 ━━━━")]
     [Tooltip("캐릭터 이미지")]
     [SerializeField] private Image _characterImage;
+
+    [SerializeField][Range(0.1f, 10f)] float _imageScale = 0.5f;
     [SerializeField] private Sprite[] _characterSprites;
 
     private void Awake()
     {
-        _characterImage.sprite = _characterSprites[Random.Range(0, _characterSprites.Length)];
+        RefreshCG();
+    }
+
+    private void RefreshCG()
+    {
+        Sprite CG = _characterSprites[Random.Range(0, _characterSprites.Length)];
+        float width = CG.rect.width;
+        float height = CG.rect.height;
+        
+        DebugTool.Log($"스프라이트 크기 : {CG.rect.width}x{CG.rect.height}", DebugType.UI, this);
+        
+        _characterImage.rectTransform.sizeDelta = new Vector2(width * _imageScale, height * _imageScale);
+        _characterImage.rectTransform.anchoredPosition = new Vector3(0, 0);
+        _characterImage.sprite = CG;
     }
 
     private void Start()

--- a/Bismuth/Assets/Scripts/조경민/TitleSceneUI.cs
+++ b/Bismuth/Assets/Scripts/조경민/TitleSceneUI.cs
@@ -32,14 +32,28 @@ public class TitleSceneUI : MonoBehaviour
 
     private void RefreshCG()
     {
-        Sprite CG = _characterSprites[Random.Range(0, _characterSprites.Length)];
+        int randomIndex = Random.Range(0, _characterSprites.Length);
+        Sprite CG = _characterSprites[randomIndex];
         float width = CG.rect.width;
         float height = CG.rect.height;
         
         DebugTool.Log($"스프라이트 크기 : {CG.rect.width}x{CG.rect.height}", DebugType.UI, this);
         
         _characterImage.rectTransform.sizeDelta = new Vector2(width * _imageScale, height * _imageScale);
-        _characterImage.rectTransform.anchoredPosition = new Vector3(0, 0);
+        switch (randomIndex)
+        {
+            case 0:
+            case 2:
+            case 7:
+                _characterImage.rectTransform.anchoredPosition = new Vector3(80, 0);
+                break;
+            case 4:
+                _characterImage.rectTransform.anchoredPosition = new Vector3(-80, 0);
+                break;
+            default:
+                _characterImage.rectTransform.anchoredPosition = new Vector3(0, 0);
+                break;
+        }
         _characterImage.sprite = CG;
     }
 

--- a/Bismuth/Assets/Scripts/조경민/UnitInfoPanelUI.cs
+++ b/Bismuth/Assets/Scripts/조경민/UnitInfoPanelUI.cs
@@ -11,14 +11,14 @@ public class UnitInfoPanelUI : MonoBehaviour
     [SerializeField] private TMP_Text _levelText;
     [Tooltip("단계")]
     [SerializeField] private TMP_Text _tierText;
-    [Tooltip("스탯")]
-    [SerializeField] private TMP_Text _statText;
+    [Tooltip("타겟팅 방법")]
+    [SerializeField] private TMP_Text _attackTypeText;
     [Tooltip("강화")]
     [SerializeField] private TMP_Text _upgradeText;
     [Tooltip("판매")]
     [SerializeField] private TMP_Text _sellText;
-    [Tooltip("설명")]
-    [SerializeField] private TMP_Text _descriptionText;
+    [Tooltip("스탯")]
+    [SerializeField] private TMP_Text _statText;
     [Tooltip("업그레이드 소모 비용")]
     [SerializeField] private TMP_Text _upgradeGoldText;
     [Tooltip("판매 획득 비용")]
@@ -100,16 +100,43 @@ public class UnitInfoPanelUI : MonoBehaviour
         _tierText.text = $"{_unitStat.Tier} {LocalizationManager.Instance.Get("TIER")}";
         _upgradeText.text = LocalizationManager.Instance.Get("LEVEL_UP");
         _sellText.text = LocalizationManager.Instance.Get("SELL");
-        _descriptionText.text = "---";
+        _attackTypeText.text = $"[ {GetAttackType()} ]";
+    }
+
+    private string GetAttackType()
+    {
+        if (_unitStat.attackTypes == UnitData.AttackTypes.Targeting)
+        {
+            switch (_unitStat.AttackTargetCount)
+            {
+                case 1:  // 단일 타겟
+                    return LocalizationManager.Instance.Get("SINGLE_TARGET");
+
+                case 2:  // 2중 타겟
+                    return LocalizationManager.Instance.Get("DOUBLE_TARGET");
+
+                case 3:  // 3중 타겟
+                    return LocalizationManager.Instance.Get("TRIPLE_TARGET");
+
+                default:
+                    return LocalizationManager.Instance.Get("WIDE_RANGE_ATTACK");
+            }
+        }
+        else if (_unitStat.attackTypes == UnitData.AttackTypes.AOE)
+        {
+            return LocalizationManager.Instance.Get("WIDE_RANGE_ATTACK");
+        }
+
+        return "";
     }
 
     public void RefreshStats()
     {
         _levelText.text = $"Lv {_unitStat.Level}";
 
-        _statText.text =
-            $"{LocalizationManager.Instance.Get("ATTACK_POWER")} : {_unitStat.CurrentAttackPower}" +
-            $"\n{LocalizationManager.Instance.Get("ATTACK_SPEED")} : {_unitStat.AttackSpeed}";
+        _statText.text = $"{LocalizationManager.Instance.Get("ATTACK_POWER")} : {_unitStat.CurrentAttackPower}" + 
+            $"\n{LocalizationManager.Instance.Get("ATTACK_SPEED")} : {_unitStat.AttackSpeed}" + 
+            $"\n{LocalizationManager.Instance.Get("RANGE")} : {_unitStat.Range}";
 
         PlayerUIController controller = _collectUnitInfo.PlayerUIController;
         if (_unitStat.Level >= controller.MaxUnitLevel)
@@ -121,7 +148,7 @@ public class UnitInfoPanelUI : MonoBehaviour
             int upgradeGold = controller.CalculateUpgradeGold(_unitStat.Level, _unitStat.Tier);
             _upgradeGoldText.text = $"{upgradeGold}";
         }
-        
+
         int sellGold = controller.GetSellGold(_unitStat);
         _sellGoldText.text = $"{sellGold}";
     }
@@ -131,8 +158,8 @@ public class UnitInfoPanelUI : MonoBehaviour
         _nameText.text = "";
         _levelText.text = "";
         _tierText.text = "";
+        _attackTypeText.text = "";
         _statText.text = "";
-        _descriptionText.text = "";
         _upgradeGoldText.text = "";
         _sellGoldText.text = "";
 


### PR DESCRIPTION
## 기능 추가
- [style] 게임로고 변경
- [style] 게임방법 일본어 추가
- [feat] 슬로우 및 오크 버프 시 색상필터 적용 + 오크 시너지 구현
- [test] 유닛 이동 클릭 유지 시간 조절 가능하도록 변경

## 버그 픽스 / 변경 사항
- [fix] 비활성 도감 팝업에서 코루틴 갱신 방지
- [fix] P 입력 시 setting 창이 출력되는 문제 해결
- [fix] 유닛 정보 UI 판매 가격 정상 표시
- [fix] 유닛 판매 가격 계산식 변경
- [fix] 모든 버튼 클릭 SFX 추가
- [fix] 정비시간 동안 일시정지 단축키 작동하지 않도록 변경
- [fix] 합성 시 레벨이 낮은 유닛이 먼저 소비되도록 변경
- [fix] 타이틀 CG 스프라이트 크기에 맞게 출력되도록 수정